### PR TITLE
ACM-17986: remove data from CAPA secret

### DIFF
--- a/charts/cluster-api-provider-aws/templates/v1_secret_capa-manager-bootstrap-credentials.yaml
+++ b/charts/cluster-api-provider-aws/templates/v1_secret_capa-manager-bootstrap-credentials.yaml
@@ -1,6 +1,4 @@
 apiVersion: v1
-data:
-  credentials: '{{ .Values.aws.encodedCredentials }}'
 kind: Secret
 metadata:
   labels:

--- a/config/cluster-api-provider-aws/kustomization.yaml
+++ b/config/cluster-api-provider-aws/kustomization.yaml
@@ -76,6 +76,8 @@ patches:
       kind: ServiceAccount
       name: capa-controller-manager
     patch: |-
+      - op: remove
+        path: /data
   # Replace sceret with AWS credentials helm chart value
   - target:
       version: v1

--- a/config/cluster-api-provider-aws/kustomization.yaml
+++ b/config/cluster-api-provider-aws/kustomization.yaml
@@ -76,10 +76,6 @@ patches:
       kind: ServiceAccount
       name: capa-controller-manager
     patch: |-
-      - op: replace
-        path: /metadata/annotations
-        value:
-          iam.amazonaws.com/role: '{{ .Values.aws.iamRole }}'
   # Replace sceret with AWS credentials helm chart value
   - target:
       version: v1


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ACM-17986

This change removes the data field from the bootstrap credentials secret. Users will have to manually add this credential to the secret, but this change will prevent any secret data from being overwritten