### PR TITLE
ACM-16486 sync charts - update sync release-4.19 -> release-2.9

### DIFF
--- a/charts/Makefile
+++ b/charts/Makefile
@@ -1,5 +1,5 @@
-OCP_VERSION ?= 4.18
-BRANCH ?= release-4.18
+OCP_VERSION ?= 4.19
+BRANCH ?= release-4.19
 SYNC2CHARTS ?= true
 ORGREPO ?= https://github.com/openshift
 


### PR DESCRIPTION
ACM-16486 - sync https://github.com/openshift [cluster-api, cluster-api-provider-aws] @release-4.19 -> release-2.9 branch
