### PR TITLE
add cluster-api-provider-openshift-assisted

### DIFF
--- a/charts/Makefile
+++ b/charts/Makefile
@@ -2,35 +2,63 @@ OCP_VERSION ?= 4.19
 BRANCH ?= master
 SYNC2CHARTS ?= true
 ORGREPO ?= https://github.com/openshift
+PROJECTS = \
+	cluster-api \
+	cluster-api-provider-aws \
+	cluster-api-provider-openshift-assisted
 
-build-cluster-api-chart: PROJECT = cluster-api
-build-cluster-api-aws-chart: PROJECT = cluster-api-provider-aws
-build-cluster-api-azure-chart: PROJECT = cluster-api-provider-azure
-
+ifeq ($(BRANCH),master)
+	TAG := latest
+else
+	TAG := $(patsubst release-%, %,$(BRANCH))
+endif
+CHART_VERSION = $(OCP_VERSION)
+CHART_APP_VERSION = $(OCP_VERSION)
+CHART_VALUES_IMAGE_TAG = $(OCP_VERSION)
+CHART_VALUES_IMAGE_TAG_PREFIX = "v"
+# Define specific overrides
+ORGREPO_cluster-api-provider-openshift-assisted = https://github.com/openshift-assisted
+KUSTOMIZE_CONFIG_DIRS_cluster-api-provider-openshift-assisted = "bootstrap" "controlplane"
+CHART_VERSION_cluster-api-provider-openshift-assisted = "1.0.0"
+CHART_APP_VERSION_cluster-api-provider-openshift-assisted = $(TAG)
+CHART_VALUES_IMAGE_TAG_cluster-api-provider-openshift-assisted = $(TAG)
+CHART_VALUES_IMAGE_TAG_PREFIX_cluster-api-provider-openshift-assisted = ""
 WKDIR ?= ../out
-BUILTDIR=$(WKDIR)/$(PROJECT)/config/tmp
+
+.PHONY: build-cluster-api-chart build-cluster-api-provider-aws-chart build-cluster-api-provider-azure-chart build-cluster-api-provider-openshift-assisted-chart
+
+# Define the build target for each project
+define make-chart-target
+build-$(1)-chart:
+	@echo "Building $(1) chart"
+	WKDIR="$(WKDIR)" \
+	ORGREPO="$(if $(ORGREPO_$(1)),$(ORGREPO_$(1)),$(ORGREPO))" \
+	KUSTOMIZE_CONFIG_DIRS="$(if $(KUSTOMIZE_CONFIG_DIRS_$(1)),$(KUSTOMIZE_CONFIG_DIRS_$(1)),)" \
+	PROJECT="$(1)" \
+	BRANCH="$(BRANCH)" \
+	../scripts/build.sh
+	BUILTDIR="$(WKDIR)/$(1)/config/tmp" \
+	CHART_VERSION="$(if $(CHART_VERSION_$(1)),$(CHART_VERSION_$(1)),$(CHART_VERSION))" \
+	CHART_APP_VERSION="$(if $(CHART_APP_VERSION_$(1)),$(CHART_APP_VERSION_$(1)),$(CHART_APP_VERSION))" \
+	CHART_VALUES_IMAGE_TAG="$(if $(CHART_VALUES_IMAGE_TAG_$(1)),$(CHART_VALUES_IMAGE_TAG_$(1)),$(CHART_VALUES_IMAGE_TAG))" \
+	CHART_VALUES_IMAGE_TAG_PREFIX="$(if $(CHART_VALUES_IMAGE_TAG_PREFIX_$(1)),$(CHART_VALUES_IMAGE_TAG_PREFIX_$(1)),$(CHART_VALUES_IMAGE_TAG_PREFIX))" \
+	SYNC2CHARTS="$(SYNC2CHARTS)" \
+	PROJECT="$(1)" \
+	../scripts/sync2chart.sh
+endef
+
+$(foreach proj,$(PROJECTS),$(eval $(call make-chart-target,$(proj))))
 
 .PHONY: build
-build: build-cluster-api-chart build-cluster-api-aws-chart build-cluster-api-azure-chart
-
-.PHONY: build-cluster-api-chart
-build-cluster-api-chart:
-	WKDIR=$(WKDIR) ORGREPO=$(ORGREPO) PROJECT=$(PROJECT) BRANCH=$(BRANCH) ../scripts/build.sh
-	OCP_VERSION=$(OCP_VERSION) SYNC2CHARTS=$(SYNC2CHARTS) BUILTDIR="$(BUILTDIR)" PROJECT=$(PROJECT) ../scripts/sync2chart.sh
-
-.PHONY: build-cluster-api-aws-chart
-build-cluster-api-aws-chart:
-	WKDIR=$(WKDIR) ORGREPO=$(ORGREPO) PROJECT=$(PROJECT) BRANCH=$(BRANCH) ../scripts/build.sh
-	OCP_VERSION=$(OCP_VERSION) SYNC2CHARTS=$(SYNC2CHARTS) BUILTDIR="$(BUILTDIR)" PROJECT=$(PROJECT) ../scripts/sync2chart.sh
+build: $(addprefix build-,$(addsuffix -chart, $(PROJECTS)))
 
 .PHONY: test-chart-crc
 test-chart-crc:
 	# run the deploy script with crc 
 	(cd ..; export PROJECT_ONLY=$(PROJECT) ; ./scripts/deploy-charts-crc.sh )
-	
+
 .PHONY: build-cluster-api-azure-chart
 build-cluster-api-azure-chart: 
-
 
 .PHONY: release-chart
 release-chart:

--- a/charts/cluster-api-provider-openshift-assisted/.helmignore
+++ b/charts/cluster-api-provider-openshift-assisted/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cluster-api-provider-openshift-assisted/Chart.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cluster-api-provider-openshift-assisted
+description: Cluster API Bootstrap and Controlplane providers for OpenShift Assisted Installer
+type: application
+version: "1.0.0"
+appVersion: "latest"

--- a/charts/cluster-api-provider-openshift-assisted/crds/apiextensions.k8s.io_v1_customresourcedefinition_openshiftassistedconfigs.bootstrap.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/crds/apiextensions.k8s.io_v1_customresourcedefinition_openshiftassistedconfigs.bootstrap.cluster.x-k8s.io.yaml
@@ -1,0 +1,334 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  labels:
+    cluster.x-k8s.io/v1beta1: v1alpha1
+  name: openshiftassistedconfigs.bootstrap.cluster.x-k8s.io
+spec:
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    kind: OpenshiftAssistedConfig
+    listKind: OpenshiftAssistedConfigList
+    plural: openshiftassistedconfigs
+    shortNames:
+    - oac
+    - oacs
+    singular: openshiftassistedconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenshiftAssistedConfig is the Schema for the openshiftassistedconfig
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenshiftAssistedConfigSpec defines the desired state of
+              OpenshiftAssistedConfig
+            properties:
+              additionalNTPSources:
+                description: |-
+                  AdditionalNTPSources is a list of NTP sources (hostname or IP) to be added to all cluster
+                  hosts. They are added to any NTP sources that were configured through other means.
+                items:
+                  type: string
+                type: array
+              additionalTrustBundle:
+                description: |-
+                  PEM-encoded X.509 certificate bundle. Hosts discovered by this
+                  infra-env will trust the certificates in this bundle. Clusters formed
+                  from the hosts discovered by this infra-env will also trust the
+                  certificates in this bundle.
+                type: string
+              cpuArchitecture:
+                default: x86_64
+                description: CpuArchitecture specifies the target CPU architecture.
+                  Default is x86_64
+                type: string
+              kernelArguments:
+                description: |-
+                  KernelArguments is the additional kernel arguments to be passed during boot time of the discovery image.
+                  Applicable for both iPXE, and ISO streaming from Image Service.
+                items:
+                  properties:
+                    operation:
+                      description: Operation is the operation to apply on the kernel
+                        argument.
+                      enum:
+                      - append
+                      - replace
+                      - delete
+                      type: string
+                    value:
+                      description: |-
+                        Value can have the form <parameter> or <parameter>=<value>. The following examples should be supported:
+                        rd.net.timeout.carrier=60
+                        isolcpus=1,2,10-20,100-2000:2/25
+                        quiet
+                      pattern: ^(?:(?:[^ \t\n\r"]+)|(?:"[^"]*"))+$
+                      type: string
+                  type: object
+                type: array
+              nmStateConfigLabelSelector:
+                description: |-
+                  NmstateConfigLabelSelector associates NMStateConfigs for hosts that are considered part
+                  of this installation environment.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeRegistration:
+                description: NodeRegistrationOption holds fields related to registering
+                  nodes to the cluster
+                properties:
+                  kubeletExtraLabels:
+                    description: KubeletExtraLabels passes extra labels to kubelet.
+                    items:
+                      type: string
+                    type: array
+                  name:
+                    description: Defaults to the hostname of the node if not provided.
+                    type: string
+                type: object
+              osImageVersion:
+                description: |-
+                  OSImageVersion is the version of OS image to use when generating the InfraEnv.
+                  The version should refer to an OSImage specified in the AgentServiceConfig
+                  (i.e. OSImageVersion should equal to an OpenshiftVersion in OSImages list).
+                  Note: OSImageVersion can't be specified along with ClusterRef.
+                type: string
+              proxy:
+                description: |-
+                  Proxy defines the proxy settings for agents and clusters that use the InfraEnv. If
+                  unset, the agents and clusters will not be configured to use a proxy.
+                properties:
+                  httpProxy:
+                    description: HTTPProxy is the URL of the proxy for HTTP requests.
+                    type: string
+                  httpsProxy:
+                    description: HTTPSProxy is the URL of the proxy for HTTPS requests.
+                    type: string
+                  noProxy:
+                    description: |-
+                      NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be
+                      used.
+                    type: string
+                type: object
+              pullSecretRef:
+                description: PullSecretRef is the reference to the secret to use when
+                  pulling images.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              sshAuthorizedKey:
+                description: SSHAuthorizedKey is a SSH public keys that will be added
+                  to all agents for use in debugging.
+                type: string
+            type: object
+          status:
+            description: OpenshiftAssistedConfigStatus defines the observed state
+              of OpenshiftAssistedConfig
+            properties:
+              agentRef:
+                description: AgentRef references the agent this agent bootstrap config
+                  has booted
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: Conditions defines current service state of the OpenshiftAssistedConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores
+                  the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors
+                type: string
+              infraEnvRef:
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
+                  InfraEnvRef references the infra env to generate the ISO
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              isoDownloadURL:
+                description: ISODownloadURL is the url for the live-iso to be downloaded
+                  from Assisted Installer
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready indicates the BootstrapData field is ready to be
+                  consumed
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/cluster-api-provider-openshift-assisted/crds/apiextensions.k8s.io_v1_customresourcedefinition_openshiftassistedconfigtemplates.bootstrap.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/crds/apiextensions.k8s.io_v1_customresourcedefinition_openshiftassistedconfigtemplates.bootstrap.cluster.x-k8s.io.yaml
@@ -1,0 +1,240 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  labels:
+    cluster.x-k8s.io/v1beta1: v1alpha1
+  name: openshiftassistedconfigtemplates.bootstrap.cluster.x-k8s.io
+spec:
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    kind: OpenshiftAssistedConfigTemplate
+    listKind: OpenshiftAssistedConfigTemplateList
+    plural: openshiftassistedconfigtemplates
+    singular: openshiftassistedconfigtemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenshiftAssistedConfigTemplate is the Schema for the openshiftassistedconfigtemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenshiftAssistedConfigTemplateSpec defines the desired state
+              of OpenshiftAssistedConfigTemplate
+            properties:
+              template:
+                description: OpenshiftAssistedConfig template
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: OpenshiftAssistedConfigSpec defines the desired state
+                      of OpenshiftAssistedConfig
+                    properties:
+                      additionalNTPSources:
+                        description: |-
+                          AdditionalNTPSources is a list of NTP sources (hostname or IP) to be added to all cluster
+                          hosts. They are added to any NTP sources that were configured through other means.
+                        items:
+                          type: string
+                        type: array
+                      additionalTrustBundle:
+                        description: |-
+                          PEM-encoded X.509 certificate bundle. Hosts discovered by this
+                          infra-env will trust the certificates in this bundle. Clusters formed
+                          from the hosts discovered by this infra-env will also trust the
+                          certificates in this bundle.
+                        type: string
+                      cpuArchitecture:
+                        default: x86_64
+                        description: CpuArchitecture specifies the target CPU architecture.
+                          Default is x86_64
+                        type: string
+                      kernelArguments:
+                        description: |-
+                          KernelArguments is the additional kernel arguments to be passed during boot time of the discovery image.
+                          Applicable for both iPXE, and ISO streaming from Image Service.
+                        items:
+                          properties:
+                            operation:
+                              description: Operation is the operation to apply on
+                                the kernel argument.
+                              enum:
+                              - append
+                              - replace
+                              - delete
+                              type: string
+                            value:
+                              description: |-
+                                Value can have the form <parameter> or <parameter>=<value>. The following examples should be supported:
+                                rd.net.timeout.carrier=60
+                                isolcpus=1,2,10-20,100-2000:2/25
+                                quiet
+                              pattern: ^(?:(?:[^ \t\n\r"]+)|(?:"[^"]*"))+$
+                              type: string
+                          type: object
+                        type: array
+                      nmStateConfigLabelSelector:
+                        description: |-
+                          NmstateConfigLabelSelector associates NMStateConfigs for hosts that are considered part
+                          of this installation environment.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeRegistration:
+                        description: NodeRegistrationOption holds fields related to
+                          registering nodes to the cluster
+                        properties:
+                          kubeletExtraLabels:
+                            description: KubeletExtraLabels passes extra labels to
+                              kubelet.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: Defaults to the hostname of the node if not
+                              provided.
+                            type: string
+                        type: object
+                      osImageVersion:
+                        description: |-
+                          OSImageVersion is the version of OS image to use when generating the InfraEnv.
+                          The version should refer to an OSImage specified in the AgentServiceConfig
+                          (i.e. OSImageVersion should equal to an OpenshiftVersion in OSImages list).
+                          Note: OSImageVersion can't be specified along with ClusterRef.
+                        type: string
+                      proxy:
+                        description: |-
+                          Proxy defines the proxy settings for agents and clusters that use the InfraEnv. If
+                          unset, the agents and clusters will not be configured to use a proxy.
+                        properties:
+                          httpProxy:
+                            description: HTTPProxy is the URL of the proxy for HTTP
+                              requests.
+                            type: string
+                          httpsProxy:
+                            description: HTTPSProxy is the URL of the proxy for HTTPS
+                              requests.
+                            type: string
+                          noProxy:
+                            description: |-
+                              NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be
+                              used.
+                            type: string
+                        type: object
+                      pullSecretRef:
+                        description: PullSecretRef is the reference to the secret
+                          to use when pulling images.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sshAuthorizedKey:
+                        description: SSHAuthorizedKey is a SSH public keys that will
+                          be added to all agents for use in debugging.
+                        type: string
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+          status:
+            description: OpenshiftAssistedConfigTemplateStatus defines the observed
+              state of OpenshiftAssistedConfigTemplate
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/cluster-api-provider-openshift-assisted/crds/apiextensions.k8s.io_v1_customresourcedefinition_openshiftassistedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/crds/apiextensions.k8s.io_v1_customresourcedefinition_openshiftassistedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -1,0 +1,670 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  labels:
+    cluster.x-k8s.io/v1beta1: v1alpha2
+  name: openshiftassistedcontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  group: controlplane.cluster.x-k8s.io
+  names:
+    kind: OpenshiftAssistedControlPlane
+    listKind: OpenshiftAssistedControlPlaneList
+    plural: openshiftassistedcontrolplanes
+    shortNames:
+    - oacp
+    - oacps
+    singular: openshiftassistedcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: This denotes whether or not the control plane has the uploaded
+        kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Total number of machines desired by this control plane
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: Time duration since creation of KubeadmControlPlane
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: OpenShift version associated with this control plane
+      jsonPath: .spec.distributionVersion
+      name: Distribution Version
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: OpenshiftAssistedControlPlane is the Schema for the openshiftassistedcontrolplane
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenshiftAssistedControlPlaneSpec defines the desired state
+              of OpenshiftAssistedControlPlane
+            properties:
+              config:
+                description: Config specs for the OpenshiftAssistedControlPlane
+                properties:
+                  apiVIPs:
+                    description: |-
+                      APIVIPs are the virtual IPs used to reach the OpenShift cluster's API.
+                      Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at
+                      most one IP address per IP stack used). The order of stacks should be the same as order
+                      of subnets in Cluster Networks, Service Networks, and Machine Networks.
+                    items:
+                      type: string
+                    maxItems: 2
+                    type: array
+                  baseDomain:
+                    description: BaseDomain is the base domain to which the cluster
+                      should belong.
+                    type: string
+                  capabilities:
+                    description: Capabilities specifies the capabilities set during
+                      an OpenShift cluster installation.
+                    properties:
+                      additionalEnabledCapabilities:
+                        description: |-
+                          AdditionalEnabledCapabilities is a list of OpenShift capabilities to specifically enable
+                          during the installation of the workload cluster. It is empty by default.
+                        items:
+                          type: string
+                        type: array
+                      baselineCapability:
+                        description: |-
+                          BaselineCapability provides a default set of capabilities to enable during the installation.
+                          Valid values are vCurrent, v4.x, or None. See the OpenShift doc for more details.
+                          Defaults to None for baremetal platform workload clusters or vCurrent otherwise.
+                        type: string
+                    type: object
+                  clusterName:
+                    description: |-
+                      ClusterName is the friendly name of the cluster. It is used for subdomains,
+                      some resource tagging, and other instances where a friendly name for the
+                      cluster is useful.
+                      If not defined ClusterName will be set as the CAPI ClusterName
+                    type: string
+                  diskEncryption:
+                    description: DiskEncryption is the configuration to enable/disable
+                      disk encryption for cluster nodes.
+                    properties:
+                      enableOn:
+                        default: none
+                        description: Enable/disable disk encryption on master nodes,
+                          worker nodes, or all nodes.
+                        enum:
+                        - none
+                        - all
+                        - masters
+                        - workers
+                        type: string
+                      mode:
+                        description: The disk encryption mode to use.
+                        enum:
+                        - tpmv2
+                        - tang
+                        type: string
+                      tangServers:
+                        description: JSON-formatted string containing additional information
+                          regarding tang's configuration
+                        type: string
+                    type: object
+                  imageRegistryRef:
+                    description: |-
+                      ImageRegistryRef is a reference to a configmap containing both the additional
+                      image registries and their corresponding certificate bundles to be used in the spoke cluster
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  ingressVIPs:
+                    description: |-
+                      IngressVIPs are the virtual IPs used for cluster ingress traffic.
+                      Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at
+                      most one IP address per IP stack used). The order of stacks should be the same as order
+                      of subnets in Cluster Networks, Service Networks, and Machine Networks.
+                    items:
+                      type: string
+                    maxItems: 2
+                    type: array
+                  manifestsConfigMapRefs:
+                    description: |-
+                      ManifestsConfigMapRefs is an array of references to user-provided manifests ConfigMaps to
+                      add to or replace manifests that are generated by the installer.
+                      Manifest names in each ConfigMap should be unique across all referenced ConfigMaps.
+                    items:
+                      description: ManifestsConfigMapReference is a reference to a
+                        manifests ConfigMap
+                      properties:
+                        name:
+                          description: Name is the name of the ConfigMap that this
+                            refers to
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  mastersSchedulable:
+                    description: Set to true to allow control plane nodes to be schedulable
+                    type: boolean
+                  proxy:
+                    description: Proxy defines the proxy settings used for the install
+                      config
+                    properties:
+                      httpProxy:
+                        description: HTTPProxy is the URL of the proxy for HTTP requests.
+                        type: string
+                      httpsProxy:
+                        description: HTTPSProxy is the URL of the proxy for HTTPS
+                          requests.
+                        type: string
+                      noProxy:
+                        description: |-
+                          NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be
+                          used.
+                        type: string
+                    type: object
+                  pullSecretRef:
+                    description: PullSecretRef references pull secret necessary for
+                      the cluster installation
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  sshAuthorizedKey:
+                    description: SSHAuthorizedKey ssh key for accessing the cluster
+                      nodes after reboot
+                    type: string
+                required:
+                - baseDomain
+                type: object
+              distributionVersion:
+                description: DistributionVersion describes the targeted OpenShift
+                  version
+                type: string
+              machineTemplate:
+                properties:
+                  infrastructureRef:
+                    description: |-
+                      InfrastructureRef is a required reference to a custom resource
+                      offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  nodeDeletionTimeout:
+                    description: |-
+                      NodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
+                      hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                      If no value is provided, the default value for this property of the Machine resource will be used.
+                    type: string
+                  nodeDrainTimeout:
+                    description: |-
+                      NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                      The default value is 0, meaning that the node can be drained without any time limitations.
+                      NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                    type: string
+                  nodeVolumeDetachTimeout:
+                    description: |-
+                      NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                      to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                    type: string
+                required:
+                - infrastructureRef
+                type: object
+              openshiftAssistedConfigSpec:
+                description: OpenshiftAssistedConfigSpec defines the desired state
+                  of OpenshiftAssistedConfig
+                properties:
+                  additionalNTPSources:
+                    description: |-
+                      AdditionalNTPSources is a list of NTP sources (hostname or IP) to be added to all cluster
+                      hosts. They are added to any NTP sources that were configured through other means.
+                    items:
+                      type: string
+                    type: array
+                  additionalTrustBundle:
+                    description: |-
+                      PEM-encoded X.509 certificate bundle. Hosts discovered by this
+                      infra-env will trust the certificates in this bundle. Clusters formed
+                      from the hosts discovered by this infra-env will also trust the
+                      certificates in this bundle.
+                    type: string
+                  cpuArchitecture:
+                    default: x86_64
+                    description: CpuArchitecture specifies the target CPU architecture.
+                      Default is x86_64
+                    type: string
+                  kernelArguments:
+                    description: |-
+                      KernelArguments is the additional kernel arguments to be passed during boot time of the discovery image.
+                      Applicable for both iPXE, and ISO streaming from Image Service.
+                    items:
+                      properties:
+                        operation:
+                          description: Operation is the operation to apply on the
+                            kernel argument.
+                          enum:
+                          - append
+                          - replace
+                          - delete
+                          type: string
+                        value:
+                          description: |-
+                            Value can have the form <parameter> or <parameter>=<value>. The following examples should be supported:
+                            rd.net.timeout.carrier=60
+                            isolcpus=1,2,10-20,100-2000:2/25
+                            quiet
+                          pattern: ^(?:(?:[^ \t\n\r"]+)|(?:"[^"]*"))+$
+                          type: string
+                      type: object
+                    type: array
+                  nmStateConfigLabelSelector:
+                    description: |-
+                      NmstateConfigLabelSelector associates NMStateConfigs for hosts that are considered part
+                      of this installation environment.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  nodeRegistration:
+                    description: NodeRegistrationOption holds fields related to registering
+                      nodes to the cluster
+                    properties:
+                      kubeletExtraLabels:
+                        description: KubeletExtraLabels passes extra labels to kubelet.
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Defaults to the hostname of the node if not provided.
+                        type: string
+                    type: object
+                  osImageVersion:
+                    description: |-
+                      OSImageVersion is the version of OS image to use when generating the InfraEnv.
+                      The version should refer to an OSImage specified in the AgentServiceConfig
+                      (i.e. OSImageVersion should equal to an OpenshiftVersion in OSImages list).
+                      Note: OSImageVersion can't be specified along with ClusterRef.
+                    type: string
+                  proxy:
+                    description: |-
+                      Proxy defines the proxy settings for agents and clusters that use the InfraEnv. If
+                      unset, the agents and clusters will not be configured to use a proxy.
+                    properties:
+                      httpProxy:
+                        description: HTTPProxy is the URL of the proxy for HTTP requests.
+                        type: string
+                      httpsProxy:
+                        description: HTTPSProxy is the URL of the proxy for HTTPS
+                          requests.
+                        type: string
+                      noProxy:
+                        description: |-
+                          NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be
+                          used.
+                        type: string
+                    type: object
+                  pullSecretRef:
+                    description: PullSecretRef is the reference to the secret to use
+                      when pulling images.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  sshAuthorizedKey:
+                    description: SSHAuthorizedKey is a SSH public keys that will be
+                      added to all agents for use in debugging.
+                    type: string
+                type: object
+              replicas:
+                format: int32
+                type: integer
+            required:
+            - distributionVersion
+            - machineTemplate
+            type: object
+          status:
+            description: OpenshiftAssistedControlPlaneStatus defines the observed
+              state of OpenshiftAssistedControlPlane
+            properties:
+              clusterDeploymentRef:
+                description: ClusterDeploymentRef references the ClusterDeployment
+                  used to create the cluster
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: Conditions defines current service state of the KubeadmControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              distributionVersion:
+                description: |-
+                  DistributionVersion represents the current OpenShift version installed on the
+                  control plane machines in the cluster.
+                type: string
+              failureMessage:
+                description: |-
+                  ErrorMessage indicates that there is a terminal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason indicates that there is a terminal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+                type: string
+              initialized:
+                description: |-
+                  Initialized denotes whether or not the control plane has the
+                  uploaded kubeadm-config configmap.
+                type: boolean
+              ready:
+                description: |-
+                  Ready denotes that the OpenshiftAssistedControlPlane API Server became ready during initial provisioning
+                  to receive requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane
+                  machines.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this control plane
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  Selector is the label selector in string format to avoid introspection
+                  by clients, and is used to provide the CRD-based integration for the
+                  scale subresource and additional integrations for things like kubectl
+                  describe.. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machines targeted by this control plane.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet ready or machines
+                  that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this control plane
+                  that have the desired template spec.
+                format: int32
+                type: integer
+              version:
+                description: |-
+                  Version represents the minimum Kubernetes version for the control plane machines
+                  in the cluster.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/charts/cluster-api-provider-openshift-assisted/templates/apps_v1_deployment_capoa-bootstrap-controller-manager.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/apps_v1_deployment_capoa-bootstrap-controller-manager.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capoa-bootstrap-controller-manager
+  namespace: capoa-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: capoa-bootstrap-controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: capoa-bootstrap-controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: '{{ .Values.bootstrap.image.url  }}:{{ .Values.bootstrap.image.tag  }}'
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: capoa-bootstrap-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/charts/cluster-api-provider-openshift-assisted/templates/apps_v1_deployment_capoa-controlplane-controller-manager.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/apps_v1_deployment_capoa-controlplane-controller-manager.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capoa-controlplane-controller-manager
+  namespace: capoa-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: capoa-controlplane-controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: capoa-controlplane-controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        command:
+        - /manager
+        image: '{{ .Values.controlplane.image.url  }}:{{ .Values.controlplane.image.tag  }}'
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: capoa-controlplane-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_clusterrole_capoa-bootstrap-manager-role.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_clusterrole_capoa-bootstrap-manager-role.yaml
@@ -1,0 +1,100 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capoa-bootstrap-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - agents
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - infraenvs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - machines
+  - machinesets
+  - machinesets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - agentclusterinstalls
+  - agentclusterinstalls/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - metal3machines
+  - metal3machinetemplates
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - metal3.io
+  resources:
+  - baremetalhosts
+  verbs:
+  - list
+  - watch

--- a/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_clusterrole_capoa-controlplane-manager-role.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_clusterrole_capoa-controlplane-manager-role.yaml
@@ -1,0 +1,151 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capoa-controlplane-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - openshiftassistedconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclustersets/join
+  verbs:
+  - create
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  - machines
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  verbs:
+  - list
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - openshiftassistedcontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - openshiftassistedcontrolplanes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - openshiftassistedcontrolplanes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - agentclusterinstalls
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - agentclusterinstalls/status
+  verbs:
+  - get
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterimagesets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments/status
+  verbs:
+  - get
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - metal3machines
+  - metal3machinetemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_capoa-bootstrap-manager-rolebinding.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_capoa-bootstrap-manager-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capoa-bootstrap-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capoa-bootstrap-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capoa-bootstrap-controller-manager
+  namespace: capoa-system

--- a/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_capoa-controlplane-manager-rolebinding.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_capoa-controlplane-manager-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capoa-controlplane-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capoa-controlplane-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capoa-controlplane-controller-manager
+  namespace: capoa-system

--- a/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_role_capoa-bootstrap-leader-election-role.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_role_capoa-bootstrap-leader-election-role.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capoa-bootstrap-leader-election-role
+  namespace: capoa-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_role_capoa-controlplane-leader-election-role.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_role_capoa-controlplane-leader-election-role.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capoa-controlplane-leader-election-role
+  namespace: capoa-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_rolebinding_capoa-bootstrap-leader-election-rolebinding.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_rolebinding_capoa-bootstrap-leader-election-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capoa-bootstrap-leader-election-rolebinding
+  namespace: capoa-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capoa-bootstrap-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capoa-bootstrap-controller-manager
+  namespace: capoa-system

--- a/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_rolebinding_capoa-controlplane-leader-election-rolebinding.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/rbac.authorization.k8s.io_v1_rolebinding_capoa-controlplane-leader-election-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capoa-controlplane-leader-election-rolebinding
+  namespace: capoa-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capoa-controlplane-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capoa-controlplane-controller-manager
+  namespace: capoa-system

--- a/charts/cluster-api-provider-openshift-assisted/templates/v1_namespace_capoa-system.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/v1_namespace_capoa-system.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capoa-system

--- a/charts/cluster-api-provider-openshift-assisted/templates/v1_serviceaccount_capoa-bootstrap-controller-manager.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/v1_serviceaccount_capoa-bootstrap-controller-manager.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capoa-bootstrap-controller-manager
+  namespace: capoa-system

--- a/charts/cluster-api-provider-openshift-assisted/templates/v1_serviceaccount_capoa-controlplane-controller-manager.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/v1_serviceaccount_capoa-controlplane-controller-manager.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capoa-controlplane-controller-manager
+  namespace: capoa-system

--- a/charts/cluster-api-provider-openshift-assisted/values.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/values.yaml
@@ -1,0 +1,8 @@
+bootstrap:
+  image:
+    tag: latest
+    url: quay.io/edge-infrastructure/cluster-api-bootstrap-provider-openshift-assisted
+controlplane:
+  image:
+    tag: latest
+    url: quay.io/edge-infrastructure/cluster-api-controlplane-provider-openshift-assisted

--- a/config/cluster-api-provider-openshift-assisted/bootstrap/kustomization.yaml
+++ b/config/cluster-api-provider-openshift-assisted/bootstrap/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- default/
+
+patches:
+- target:
+    version: v1
+    kind: Deployment
+    name: capoa-bootstrap-controller-manager
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/image
+      value: '{{ .Values.bootstrap.image.url  }}:{{ .Values.bootstrap.image.tag  }}'

--- a/config/cluster-api-provider-openshift-assisted/controlplane/kustomization.yaml
+++ b/config/cluster-api-provider-openshift-assisted/controlplane/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- default/
+
+patches:
+- target:
+    version: v1
+    kind: Deployment
+    name: capoa-controlplane-controller-manager
+  patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/image
+      value: '{{ .Values.controlplane.image.url  }}:{{ .Values.controlplane.image.tag  }}'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,23 +29,43 @@ if [ "$SKIP_CLONE" != true -o ! -d $WKDIR/$PROJECT ] ; then
     mkdir -p $WKDIR
     rm -rf $WKDIR/$PROJECT
     mkdir $WKDIR/$PROJECT
-    git clone $ORGREPO/$PROJECT $WKDIR/$PROJECT
+    git clone --depth=1 --branch="${BRANCH}" "${ORGREPO}/${PROJECT}" "${WKDIR}/${PROJECT}"
 fi
 
 mkdir -p ../src
 export SRC_RESOURCES=$(realpath ../src/$PROJECT.yaml)
 export KUSTOMIZE_PLUGIN_HOME=$(realpath ../kustomize-plugins)
 [ -f ../$CONFIGDIR/$PROJECT/env ] && . ../$CONFIGDIR/$PROJECT/env
-cp ../$CONFIGDIR/$PROJECT/kustomization.yaml $WKDIR/$PROJECT/$CONFIGDIR
-[ -d ../$CONFIGDIR/$PROJECT/base ] && cp -a ../$CONFIGDIR/$PROJECT/base $WKDIR/$PROJECT/$CONFIGDIR
+
+if [ -z "$KUSTOMIZE_CONFIG_DIRS" ]; then
+  cp "../${CONFIGDIR}/${PROJECT}/kustomization.yaml" "${WKDIR}/${PROJECT}/${CONFIGDIR}"
+  [ -d ../${CONFIGDIR}/${PROJECT}/base ] && cp -a ../${CONFIGDIR}/${PROJECT}/base "${WKDIR}/${PROJECT}/${CONFIGDIR}"
+else
+  for subdir in ${KUSTOMIZE_CONFIG_DIRS}; do
+    cp ."./${CONFIGDIR}/${PROJECT}/${subdir}/kustomization.yaml" "${WKDIR}/${PROJECT}/${subdir}/${CONFIGDIR}"
+    [ -d "../${CONFIGDIR}/${PROJECT}/${subdir}/base" ] && \
+     cp -a "../${CONFIGDIR}/${PROJECT}/${subdir}/base" "${WKDIR}/${PROJECT}/${subdir}/${CONFIGDIR}" || \
+     echo "WARNING: No base directory found in ${CONFIGDIR}/${PROJECT}/${subdir}/base"
+  done
+fi
 
 cd $WKDIR/$PROJECT
-git checkout "$BRANCH" && git pull
+git fetch --depth=1 origin "${BRANCH}" && git checkout "${BRANCH}"
 rm -rf $CONFIGDIR/$TMPDIR
 mkdir -p $CONFIGDIR/$TMPDIR
-$KUSTOMIZE build config/default > $SRC_RESOURCES
-# do the replacements
-$KUSTOMIZE build --enable-alpha-plugins config -o $CONFIGDIR/$TMPDIR
+
+if [ -z "${KUSTOMIZE_CONFIG_DIRS}" ]; then
+  ${KUSTOMIZE} build config/default > "${SRC_RESOURCES}"
+  # do the replacements
+  ${KUSTOMIZE} build --enable-alpha-plugins config -o "${CONFIGDIR}/${TMPDIR}"
+else
+  cat /dev/null > "${SRC_RESOURCES}"
+  for subdir in ${KUSTOMIZE_CONFIG_DIRS}; do
+      ${KUSTOMIZE} build "${subdir}/config/default" >> "${SRC_RESOURCES}"
+      # do the replacements
+      ${KUSTOMIZE} build --enable-alpha-plugins "${subdir}/config" -o "${CONFIGDIR}/${TMPDIR}"
+  done
+fi
 rm -rf $CONFIGDIR/$TMPDIR/cert*
 if [ "$PROJECT" == "cluster-api" ] ; then
     rm -rf $CONFIGDIR/$TMPDIR/apiextensions.k8s.io_v1_customresourcedefinition_ip*.yaml

--- a/scripts/sync2chart.sh
+++ b/scripts/sync2chart.sh
@@ -5,8 +5,16 @@ if [ -z "$PROJECT" ] ; then
     echo "PROJECT name must be defned ex; cluster-api, cluster-api-providers-aws, cluster-api-providers-azure"
     exit -1
 fi
-if [ -z "$OCP_VERSION" ]; then
-    echo "OCP_VERSION must be defned ex; 4.18"
+if [ -z "${CHART_VERSION}" ]; then
+    echo "CHART_VERSION must be defned ex; 0.1.0"
+    exit -1
+fi
+if [ -z "${CHART_APP_VERSION}" ]; then
+    echo "CHART_APP_VERSION must be defned ex; 0.1.0"
+    exit -1
+fi
+if [ -z "${CHART_VALUES_IMAGE_TAG}" ]; then
+    echo "CHART_VALUES_IMAGE_TAG must be defned ex; 0.1.0"
     exit -1
 fi
 if [ -z "$BUILTDIR" ]; then
@@ -25,9 +33,13 @@ if [ "$SYNC2CHARTS" ] ;then
     mv $BUILTDIR/apiextensions*.yaml $CHARTDIR/crds
     mv $BUILTDIR/*.yaml $CHARTDIR/templates
 
-    echo "updating versions($OCP_VERSION) in:" "$CHARTDIR/Chart.yaml" "$CHARTDIR/values.yaml"
-    sed -i -e 's/^\(version\|appVersion\): .*/\1: "'"$OCP_VERSION"'"/' "$CHARTDIR/Chart.yaml"
-    sed -i -e 's/^\(    tag: \).*/\1v'"$OCP_VERSION"/ "$CHARTDIR/values.yaml"
+    echo "updating versions in:" "$CHARTDIR/Chart.yaml" "$CHARTDIR/values.yaml"
+    echo "* chart version: ${CHART_VERSION}"
+    echo "* chart app version: ${CHART_APP_VERSION}"
+    echo "* chart values image tag: ${CHART_VALUES_IMAGE_TAG}"
+    sed -i -e 's/^version: .*/version: "'"${CHART_VERSION}"'"/' "${CHARTDIR}/Chart.yaml"
+    sed -i -e 's/^appVersion: .*/appVersion: "'"${CHART_APP_VERSION}"'"/' "${CHARTDIR}/Chart.yaml"
+    sed -i -e 's/^\(    tag: \).*/\1'"${CHART_VALUES_IMAGE_TAG_PREFIX}${CHART_VALUES_IMAGE_TAG}"/ "$CHARTDIR/values.yaml"
     
     echo 'Run helm template after sync saving the output to ' $NEWCHART
     $HELM template $CHARTDIR --include-crds | \

--- a/src/cluster-api-provider-openshift-assisted.yaml
+++ b/src/cluster-api-provider-openshift-assisted.yaml
@@ -1,0 +1,1759 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capoa-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  labels:
+    cluster.x-k8s.io/v1beta1: v1alpha1
+  name: openshiftassistedconfigs.bootstrap.cluster.x-k8s.io
+spec:
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    kind: OpenshiftAssistedConfig
+    listKind: OpenshiftAssistedConfigList
+    plural: openshiftassistedconfigs
+    shortNames:
+    - oac
+    - oacs
+    singular: openshiftassistedconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenshiftAssistedConfig is the Schema for the openshiftassistedconfig
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenshiftAssistedConfigSpec defines the desired state of
+              OpenshiftAssistedConfig
+            properties:
+              additionalNTPSources:
+                description: |-
+                  AdditionalNTPSources is a list of NTP sources (hostname or IP) to be added to all cluster
+                  hosts. They are added to any NTP sources that were configured through other means.
+                items:
+                  type: string
+                type: array
+              additionalTrustBundle:
+                description: |-
+                  PEM-encoded X.509 certificate bundle. Hosts discovered by this
+                  infra-env will trust the certificates in this bundle. Clusters formed
+                  from the hosts discovered by this infra-env will also trust the
+                  certificates in this bundle.
+                type: string
+              cpuArchitecture:
+                default: x86_64
+                description: CpuArchitecture specifies the target CPU architecture.
+                  Default is x86_64
+                type: string
+              kernelArguments:
+                description: |-
+                  KernelArguments is the additional kernel arguments to be passed during boot time of the discovery image.
+                  Applicable for both iPXE, and ISO streaming from Image Service.
+                items:
+                  properties:
+                    operation:
+                      description: Operation is the operation to apply on the kernel
+                        argument.
+                      enum:
+                      - append
+                      - replace
+                      - delete
+                      type: string
+                    value:
+                      description: |-
+                        Value can have the form <parameter> or <parameter>=<value>. The following examples should be supported:
+                        rd.net.timeout.carrier=60
+                        isolcpus=1,2,10-20,100-2000:2/25
+                        quiet
+                      pattern: ^(?:(?:[^ \t\n\r"]+)|(?:"[^"]*"))+$
+                      type: string
+                  type: object
+                type: array
+              nmStateConfigLabelSelector:
+                description: |-
+                  NmstateConfigLabelSelector associates NMStateConfigs for hosts that are considered part
+                  of this installation environment.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeRegistration:
+                description: NodeRegistrationOption holds fields related to registering
+                  nodes to the cluster
+                properties:
+                  kubeletExtraLabels:
+                    description: KubeletExtraLabels passes extra labels to kubelet.
+                    items:
+                      type: string
+                    type: array
+                  name:
+                    description: Defaults to the hostname of the node if not provided.
+                    type: string
+                type: object
+              osImageVersion:
+                description: |-
+                  OSImageVersion is the version of OS image to use when generating the InfraEnv.
+                  The version should refer to an OSImage specified in the AgentServiceConfig
+                  (i.e. OSImageVersion should equal to an OpenshiftVersion in OSImages list).
+                  Note: OSImageVersion can't be specified along with ClusterRef.
+                type: string
+              proxy:
+                description: |-
+                  Proxy defines the proxy settings for agents and clusters that use the InfraEnv. If
+                  unset, the agents and clusters will not be configured to use a proxy.
+                properties:
+                  httpProxy:
+                    description: HTTPProxy is the URL of the proxy for HTTP requests.
+                    type: string
+                  httpsProxy:
+                    description: HTTPSProxy is the URL of the proxy for HTTPS requests.
+                    type: string
+                  noProxy:
+                    description: |-
+                      NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be
+                      used.
+                    type: string
+                type: object
+              pullSecretRef:
+                description: PullSecretRef is the reference to the secret to use when
+                  pulling images.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              sshAuthorizedKey:
+                description: SSHAuthorizedKey is a SSH public keys that will be added
+                  to all agents for use in debugging.
+                type: string
+            type: object
+          status:
+            description: OpenshiftAssistedConfigStatus defines the observed state
+              of OpenshiftAssistedConfig
+            properties:
+              agentRef:
+                description: AgentRef references the agent this agent bootstrap config
+                  has booted
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: Conditions defines current service state of the OpenshiftAssistedConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores
+                  the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors
+                type: string
+              infraEnvRef:
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
+                  InfraEnvRef references the infra env to generate the ISO
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              isoDownloadURL:
+                description: ISODownloadURL is the url for the live-iso to be downloaded
+                  from Assisted Installer
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready indicates the BootstrapData field is ready to be
+                  consumed
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  labels:
+    cluster.x-k8s.io/v1beta1: v1alpha1
+  name: openshiftassistedconfigtemplates.bootstrap.cluster.x-k8s.io
+spec:
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    kind: OpenshiftAssistedConfigTemplate
+    listKind: OpenshiftAssistedConfigTemplateList
+    plural: openshiftassistedconfigtemplates
+    singular: openshiftassistedconfigtemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenshiftAssistedConfigTemplate is the Schema for the openshiftassistedconfigtemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenshiftAssistedConfigTemplateSpec defines the desired state
+              of OpenshiftAssistedConfigTemplate
+            properties:
+              template:
+                description: OpenshiftAssistedConfig template
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: OpenshiftAssistedConfigSpec defines the desired state
+                      of OpenshiftAssistedConfig
+                    properties:
+                      additionalNTPSources:
+                        description: |-
+                          AdditionalNTPSources is a list of NTP sources (hostname or IP) to be added to all cluster
+                          hosts. They are added to any NTP sources that were configured through other means.
+                        items:
+                          type: string
+                        type: array
+                      additionalTrustBundle:
+                        description: |-
+                          PEM-encoded X.509 certificate bundle. Hosts discovered by this
+                          infra-env will trust the certificates in this bundle. Clusters formed
+                          from the hosts discovered by this infra-env will also trust the
+                          certificates in this bundle.
+                        type: string
+                      cpuArchitecture:
+                        default: x86_64
+                        description: CpuArchitecture specifies the target CPU architecture.
+                          Default is x86_64
+                        type: string
+                      kernelArguments:
+                        description: |-
+                          KernelArguments is the additional kernel arguments to be passed during boot time of the discovery image.
+                          Applicable for both iPXE, and ISO streaming from Image Service.
+                        items:
+                          properties:
+                            operation:
+                              description: Operation is the operation to apply on
+                                the kernel argument.
+                              enum:
+                              - append
+                              - replace
+                              - delete
+                              type: string
+                            value:
+                              description: |-
+                                Value can have the form <parameter> or <parameter>=<value>. The following examples should be supported:
+                                rd.net.timeout.carrier=60
+                                isolcpus=1,2,10-20,100-2000:2/25
+                                quiet
+                              pattern: ^(?:(?:[^ \t\n\r"]+)|(?:"[^"]*"))+$
+                              type: string
+                          type: object
+                        type: array
+                      nmStateConfigLabelSelector:
+                        description: |-
+                          NmstateConfigLabelSelector associates NMStateConfigs for hosts that are considered part
+                          of this installation environment.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeRegistration:
+                        description: NodeRegistrationOption holds fields related to
+                          registering nodes to the cluster
+                        properties:
+                          kubeletExtraLabels:
+                            description: KubeletExtraLabels passes extra labels to
+                              kubelet.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: Defaults to the hostname of the node if not
+                              provided.
+                            type: string
+                        type: object
+                      osImageVersion:
+                        description: |-
+                          OSImageVersion is the version of OS image to use when generating the InfraEnv.
+                          The version should refer to an OSImage specified in the AgentServiceConfig
+                          (i.e. OSImageVersion should equal to an OpenshiftVersion in OSImages list).
+                          Note: OSImageVersion can't be specified along with ClusterRef.
+                        type: string
+                      proxy:
+                        description: |-
+                          Proxy defines the proxy settings for agents and clusters that use the InfraEnv. If
+                          unset, the agents and clusters will not be configured to use a proxy.
+                        properties:
+                          httpProxy:
+                            description: HTTPProxy is the URL of the proxy for HTTP
+                              requests.
+                            type: string
+                          httpsProxy:
+                            description: HTTPSProxy is the URL of the proxy for HTTPS
+                              requests.
+                            type: string
+                          noProxy:
+                            description: |-
+                              NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be
+                              used.
+                            type: string
+                        type: object
+                      pullSecretRef:
+                        description: PullSecretRef is the reference to the secret
+                          to use when pulling images.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sshAuthorizedKey:
+                        description: SSHAuthorizedKey is a SSH public keys that will
+                          be added to all agents for use in debugging.
+                        type: string
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+          status:
+            description: OpenshiftAssistedConfigTemplateStatus defines the observed
+              state of OpenshiftAssistedConfigTemplate
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capoa-bootstrap-controller-manager
+  namespace: capoa-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capoa-bootstrap-leader-election-role
+  namespace: capoa-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capoa-bootstrap-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - agents
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - infraenvs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - machines
+  - machinesets
+  - machinesets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - agentclusterinstalls
+  - agentclusterinstalls/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - metal3machines
+  - metal3machinetemplates
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - metal3.io
+  resources:
+  - baremetalhosts
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capoa-bootstrap-leader-election-rolebinding
+  namespace: capoa-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capoa-bootstrap-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capoa-bootstrap-controller-manager
+  namespace: capoa-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capoa-bootstrap-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capoa-bootstrap-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capoa-bootstrap-controller-manager
+  namespace: capoa-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capoa-bootstrap-controller-manager
+  namespace: capoa-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: capoa-bootstrap-controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: capoa-bootstrap-controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/edge-infrastructure/cluster-api-bootstrap-provider-openshift-assisted:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: capoa-bootstrap-controller-manager
+      terminationGracePeriodSeconds: 10
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capoa-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  labels:
+    cluster.x-k8s.io/v1beta1: v1alpha2
+  name: openshiftassistedcontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  group: controlplane.cluster.x-k8s.io
+  names:
+    kind: OpenshiftAssistedControlPlane
+    listKind: OpenshiftAssistedControlPlaneList
+    plural: openshiftassistedcontrolplanes
+    shortNames:
+    - oacp
+    - oacps
+    singular: openshiftassistedcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: This denotes whether or not the control plane has the uploaded
+        kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Total number of machines desired by this control plane
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: Time duration since creation of KubeadmControlPlane
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: OpenShift version associated with this control plane
+      jsonPath: .spec.distributionVersion
+      name: Distribution Version
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: OpenshiftAssistedControlPlane is the Schema for the openshiftassistedcontrolplane
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenshiftAssistedControlPlaneSpec defines the desired state
+              of OpenshiftAssistedControlPlane
+            properties:
+              config:
+                description: Config specs for the OpenshiftAssistedControlPlane
+                properties:
+                  apiVIPs:
+                    description: |-
+                      APIVIPs are the virtual IPs used to reach the OpenShift cluster's API.
+                      Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at
+                      most one IP address per IP stack used). The order of stacks should be the same as order
+                      of subnets in Cluster Networks, Service Networks, and Machine Networks.
+                    items:
+                      type: string
+                    maxItems: 2
+                    type: array
+                  baseDomain:
+                    description: BaseDomain is the base domain to which the cluster
+                      should belong.
+                    type: string
+                  capabilities:
+                    description: Capabilities specifies the capabilities set during
+                      an OpenShift cluster installation.
+                    properties:
+                      additionalEnabledCapabilities:
+                        description: |-
+                          AdditionalEnabledCapabilities is a list of OpenShift capabilities to specifically enable
+                          during the installation of the workload cluster. It is empty by default.
+                        items:
+                          type: string
+                        type: array
+                      baselineCapability:
+                        description: |-
+                          BaselineCapability provides a default set of capabilities to enable during the installation.
+                          Valid values are vCurrent, v4.x, or None. See the OpenShift doc for more details.
+                          Defaults to None for baremetal platform workload clusters or vCurrent otherwise.
+                        type: string
+                    type: object
+                  clusterName:
+                    description: |-
+                      ClusterName is the friendly name of the cluster. It is used for subdomains,
+                      some resource tagging, and other instances where a friendly name for the
+                      cluster is useful.
+                      If not defined ClusterName will be set as the CAPI ClusterName
+                    type: string
+                  diskEncryption:
+                    description: DiskEncryption is the configuration to enable/disable
+                      disk encryption for cluster nodes.
+                    properties:
+                      enableOn:
+                        default: none
+                        description: Enable/disable disk encryption on master nodes,
+                          worker nodes, or all nodes.
+                        enum:
+                        - none
+                        - all
+                        - masters
+                        - workers
+                        type: string
+                      mode:
+                        description: The disk encryption mode to use.
+                        enum:
+                        - tpmv2
+                        - tang
+                        type: string
+                      tangServers:
+                        description: JSON-formatted string containing additional information
+                          regarding tang's configuration
+                        type: string
+                    type: object
+                  imageRegistryRef:
+                    description: |-
+                      ImageRegistryRef is a reference to a configmap containing both the additional
+                      image registries and their corresponding certificate bundles to be used in the spoke cluster
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  ingressVIPs:
+                    description: |-
+                      IngressVIPs are the virtual IPs used for cluster ingress traffic.
+                      Enter one IP address for single-stack clusters, or up to two for dual-stack clusters (at
+                      most one IP address per IP stack used). The order of stacks should be the same as order
+                      of subnets in Cluster Networks, Service Networks, and Machine Networks.
+                    items:
+                      type: string
+                    maxItems: 2
+                    type: array
+                  manifestsConfigMapRefs:
+                    description: |-
+                      ManifestsConfigMapRefs is an array of references to user-provided manifests ConfigMaps to
+                      add to or replace manifests that are generated by the installer.
+                      Manifest names in each ConfigMap should be unique across all referenced ConfigMaps.
+                    items:
+                      description: ManifestsConfigMapReference is a reference to a
+                        manifests ConfigMap
+                      properties:
+                        name:
+                          description: Name is the name of the ConfigMap that this
+                            refers to
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  mastersSchedulable:
+                    description: Set to true to allow control plane nodes to be schedulable
+                    type: boolean
+                  proxy:
+                    description: Proxy defines the proxy settings used for the install
+                      config
+                    properties:
+                      httpProxy:
+                        description: HTTPProxy is the URL of the proxy for HTTP requests.
+                        type: string
+                      httpsProxy:
+                        description: HTTPSProxy is the URL of the proxy for HTTPS
+                          requests.
+                        type: string
+                      noProxy:
+                        description: |-
+                          NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be
+                          used.
+                        type: string
+                    type: object
+                  pullSecretRef:
+                    description: PullSecretRef references pull secret necessary for
+                      the cluster installation
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  sshAuthorizedKey:
+                    description: SSHAuthorizedKey ssh key for accessing the cluster
+                      nodes after reboot
+                    type: string
+                required:
+                - baseDomain
+                type: object
+              distributionVersion:
+                description: DistributionVersion describes the targeted OpenShift
+                  version
+                type: string
+              machineTemplate:
+                properties:
+                  infrastructureRef:
+                    description: |-
+                      InfrastructureRef is a required reference to a custom resource
+                      offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  nodeDeletionTimeout:
+                    description: |-
+                      NodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
+                      hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                      If no value is provided, the default value for this property of the Machine resource will be used.
+                    type: string
+                  nodeDrainTimeout:
+                    description: |-
+                      NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                      The default value is 0, meaning that the node can be drained without any time limitations.
+                      NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                    type: string
+                  nodeVolumeDetachTimeout:
+                    description: |-
+                      NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                      to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                    type: string
+                required:
+                - infrastructureRef
+                type: object
+              openshiftAssistedConfigSpec:
+                description: OpenshiftAssistedConfigSpec defines the desired state
+                  of OpenshiftAssistedConfig
+                properties:
+                  additionalNTPSources:
+                    description: |-
+                      AdditionalNTPSources is a list of NTP sources (hostname or IP) to be added to all cluster
+                      hosts. They are added to any NTP sources that were configured through other means.
+                    items:
+                      type: string
+                    type: array
+                  additionalTrustBundle:
+                    description: |-
+                      PEM-encoded X.509 certificate bundle. Hosts discovered by this
+                      infra-env will trust the certificates in this bundle. Clusters formed
+                      from the hosts discovered by this infra-env will also trust the
+                      certificates in this bundle.
+                    type: string
+                  cpuArchitecture:
+                    default: x86_64
+                    description: CpuArchitecture specifies the target CPU architecture.
+                      Default is x86_64
+                    type: string
+                  kernelArguments:
+                    description: |-
+                      KernelArguments is the additional kernel arguments to be passed during boot time of the discovery image.
+                      Applicable for both iPXE, and ISO streaming from Image Service.
+                    items:
+                      properties:
+                        operation:
+                          description: Operation is the operation to apply on the
+                            kernel argument.
+                          enum:
+                          - append
+                          - replace
+                          - delete
+                          type: string
+                        value:
+                          description: |-
+                            Value can have the form <parameter> or <parameter>=<value>. The following examples should be supported:
+                            rd.net.timeout.carrier=60
+                            isolcpus=1,2,10-20,100-2000:2/25
+                            quiet
+                          pattern: ^(?:(?:[^ \t\n\r"]+)|(?:"[^"]*"))+$
+                          type: string
+                      type: object
+                    type: array
+                  nmStateConfigLabelSelector:
+                    description: |-
+                      NmstateConfigLabelSelector associates NMStateConfigs for hosts that are considered part
+                      of this installation environment.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  nodeRegistration:
+                    description: NodeRegistrationOption holds fields related to registering
+                      nodes to the cluster
+                    properties:
+                      kubeletExtraLabels:
+                        description: KubeletExtraLabels passes extra labels to kubelet.
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Defaults to the hostname of the node if not provided.
+                        type: string
+                    type: object
+                  osImageVersion:
+                    description: |-
+                      OSImageVersion is the version of OS image to use when generating the InfraEnv.
+                      The version should refer to an OSImage specified in the AgentServiceConfig
+                      (i.e. OSImageVersion should equal to an OpenshiftVersion in OSImages list).
+                      Note: OSImageVersion can't be specified along with ClusterRef.
+                    type: string
+                  proxy:
+                    description: |-
+                      Proxy defines the proxy settings for agents and clusters that use the InfraEnv. If
+                      unset, the agents and clusters will not be configured to use a proxy.
+                    properties:
+                      httpProxy:
+                        description: HTTPProxy is the URL of the proxy for HTTP requests.
+                        type: string
+                      httpsProxy:
+                        description: HTTPSProxy is the URL of the proxy for HTTPS
+                          requests.
+                        type: string
+                      noProxy:
+                        description: |-
+                          NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be
+                          used.
+                        type: string
+                    type: object
+                  pullSecretRef:
+                    description: PullSecretRef is the reference to the secret to use
+                      when pulling images.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  sshAuthorizedKey:
+                    description: SSHAuthorizedKey is a SSH public keys that will be
+                      added to all agents for use in debugging.
+                    type: string
+                type: object
+              replicas:
+                format: int32
+                type: integer
+            required:
+            - distributionVersion
+            - machineTemplate
+            type: object
+          status:
+            description: OpenshiftAssistedControlPlaneStatus defines the observed
+              state of OpenshiftAssistedControlPlane
+            properties:
+              clusterDeploymentRef:
+                description: ClusterDeploymentRef references the ClusterDeployment
+                  used to create the cluster
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: Conditions defines current service state of the KubeadmControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              distributionVersion:
+                description: |-
+                  DistributionVersion represents the current OpenShift version installed on the
+                  control plane machines in the cluster.
+                type: string
+              failureMessage:
+                description: |-
+                  ErrorMessage indicates that there is a terminal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason indicates that there is a terminal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+                type: string
+              initialized:
+                description: |-
+                  Initialized denotes whether or not the control plane has the
+                  uploaded kubeadm-config configmap.
+                type: boolean
+              ready:
+                description: |-
+                  Ready denotes that the OpenshiftAssistedControlPlane API Server became ready during initial provisioning
+                  to receive requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane
+                  machines.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this control plane
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  Selector is the label selector in string format to avoid introspection
+                  by clients, and is used to provide the CRD-based integration for the
+                  scale subresource and additional integrations for things like kubectl
+                  describe.. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                type: string
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machines targeted by this control plane.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet ready or machines
+                  that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  Total number of non-terminated machines targeted by this control plane
+                  that have the desired template spec.
+                format: int32
+                type: integer
+              version:
+                description: |-
+                  Version represents the minimum Kubernetes version for the control plane machines
+                  in the cluster.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: capoa-controlplane-controller-manager
+  namespace: capoa-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capoa-controlplane-leader-election-role
+  namespace: capoa-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capoa-controlplane-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - openshiftassistedconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclustersets/join
+  verbs:
+  - create
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  - machines
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  verbs:
+  - list
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - openshiftassistedcontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - openshiftassistedcontrolplanes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - openshiftassistedcontrolplanes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - agentclusterinstalls
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - agentclusterinstalls/status
+  verbs:
+  - get
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterimagesets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments/status
+  verbs:
+  - get
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - metal3machines
+  - metal3machinetemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capoa-controlplane-leader-election-rolebinding
+  namespace: capoa-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capoa-controlplane-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capoa-controlplane-controller-manager
+  namespace: capoa-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capoa-controlplane-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capoa-controlplane-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capoa-controlplane-controller-manager
+  namespace: capoa-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capoa-controlplane-controller-manager
+  namespace: capoa-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: capoa-controlplane-controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: capoa-controlplane-controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        command:
+        - /manager
+        image: quay.io/edge-infrastructure/cluster-api-controlplane-provider-openshift-assisted:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: capoa-controlplane-controller-manager
+      terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Introduced the chart for [cluster-api-provider-openshift-assisted](https://github.com/openshift-assisted/cluster-api-provider-openshift-assisted).
Refactored Makefile so that the logic is not duplicated. Added default variable values and overrides depending on the helm chart project.