### PR TITLE
Add CA bundle name and namespace to assisted bootstrap provider

### DIFF
--- a/charts/cluster-api-provider-openshift-assisted/templates/apps_v1_deployment_capoa-bootstrap-controller-manager.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/apps_v1_deployment_capoa-bootstrap-controller-manager.yaml
@@ -23,6 +23,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: ASSISTED_CA_BUNDLE_NAME
+          value: default-ingress-cert
+        - name: ASSISTED_CA_BUNDLE_NAMESPACE
+          value: openshift-config-managed
         image: '{{ .Values.bootstrap.image.url  }}:{{ .Values.bootstrap.image.tag  }}'
         imagePullPolicy: Always
         livenessProbe:

--- a/config/cluster-api-provider-openshift-assisted/bootstrap/kustomization.yaml
+++ b/config/cluster-api-provider-openshift-assisted/bootstrap/kustomization.yaml
@@ -13,3 +13,13 @@ patches:
     - op: replace
       path: /spec/template/spec/containers/0/image
       value: '{{ .Values.bootstrap.image.url  }}:{{ .Values.bootstrap.image.tag  }}'
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: ASSISTED_CA_BUNDLE_NAME
+        value: default-ingress-cert
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: ASSISTED_CA_BUNDLE_NAMESPACE
+        value: openshift-config-managed


### PR DESCRIPTION
Without this reference the bootstrap provider is unable to trust the host used to download the ignition from assisted (the route). These configs instruct the bootstrap provider to trust the cluster ingress CA bundle.

cc @rccrdpccl @serngawy 