### PR TITLE
define CA bundle related env vars for CAPOA bootstrap provider

### DIFF
--- a/charts/cluster-api-provider-openshift-assisted/templates/apps_v1_deployment_capoa-bootstrap-controller-manager.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/apps_v1_deployment_capoa-bootstrap-controller-manager.yaml
@@ -27,6 +27,10 @@ spec:
           value: default-ingress-cert
         - name: ASSISTED_CA_BUNDLE_NAMESPACE
           value: openshift-config-managed
+        - name: ASSISTED_CA_BUNDLE_RESOURCE
+          value: configmap
+        - name: ASSISTED_CA_BUNDLE_KEY
+          value: ca-bundle.crt
         image: '{{ .Values.bootstrap.image.url  }}:{{ .Values.bootstrap.image.tag  }}'
         imagePullPolicy: Always
         livenessProbe:

--- a/config/cluster-api-provider-openshift-assisted/bootstrap/kustomization.yaml
+++ b/config/cluster-api-provider-openshift-assisted/bootstrap/kustomization.yaml
@@ -23,3 +23,13 @@ patches:
       value:
         name: ASSISTED_CA_BUNDLE_NAMESPACE
         value: openshift-config-managed
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: ASSISTED_CA_BUNDLE_RESOURCE
+        value: "configmap"
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: ASSISTED_CA_BUNDLE_KEY
+        value: "ca-bundle.crt"


### PR DESCRIPTION
CAPOA changed defaults for those values, so we need to define them in the chart

cc @carbonin 