### PR TITLE
Check mce-capi-webhook-config with different builder

### DIFF
--- a/.github/workflows/ci-mce-capi-webhook-config.yaml
+++ b/.github/workflows/ci-mce-capi-webhook-config.yaml
@@ -10,12 +10,6 @@ jobs:
       run:
         working-directory: ./mce-capi-webhook-config
     steps:
-      - uses: docker/login-action@v3
-        name: Log in to registry.redhat.io
-        with:
-          registry: registry.redhat.io 
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: actions/checkout@v4
       - name: build
         run: make build

--- a/mce-capi-webhook-config/Dockerfile
+++ b/mce-capi-webhook-config/Dockerfile
@@ -1,5 +1,6 @@
+ARG BUILDER_IMAGE="registry.redhat.io/rhel8/go-toolset:latest"
 # Build the manager binary
-FROM registry.redhat.io/rhel8/go-toolset:latest AS builder
+FROM ${BUILDER_IMAGE} AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/mce-capi-webhook-config/Makefile
+++ b/mce-capi-webhook-config/Makefile
@@ -50,7 +50,7 @@ deploy: webhook
 
 # Build the docker image
 docker-build: webhook
-	docker build . -t ${IMG}
+	docker build . -t ${IMG} --build-arg BUILDER_IMAGE=registry.ci.openshift.org/stolostron/builder:go1.23-linux 
 
 # Push the docker image
 docker-push:


### PR DESCRIPTION
Change the builder image to `registry.access.redhat.com/ubi9/go-toolset:1.23` which is fine with:
* tekton,
* `make docker-build`
  * fom local PC or
  * from GitHub too.

