### PR TITLE
fix - ci-mce-capi-webhook-config.yaml and tekton build using registry.access.redhat.com

### DIFF
--- a/.github/workflows/ci-mce-capi-webhook-config.yaml
+++ b/.github/workflows/ci-mce-capi-webhook-config.yaml
@@ -10,12 +10,6 @@ jobs:
       run:
         working-directory: ./mce-capi-webhook-config
     steps:
-      - uses: docker/login-action@v3
-        name: Log in to registry.redhat.io
-        with:
-          registry: registry.redhat.io 
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: actions/checkout@v4
       - name: build
         run: make build

--- a/mce-capi-webhook-config/Dockerfile
+++ b/mce-capi-webhook-config/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.redhat.io/rhel8/go-toolset:latest AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
Change the builder image to `registry.access.redhat.com/ubi9/go-toolset:1.23` which is fine with:
* tekton,
* `make docker-build`
  * fom local PC or
  * from GitHub too.