### PR TITLE
remove release-* branches from .github/workflows/crons.yml

### DIFF
--- a/.github/workflows/crons.yml
+++ b/.github/workflows/crons.yml
@@ -6,24 +6,24 @@ on:
     - cron: "24 0 * * 3"
 
 jobs:
-  call-sync-release-2_8:
+  call-sync-backplane-2_8:
     permissions:
       contents: write
       pull-requests: write
     uses: ./.github/workflows/sync-providers.yaml
     with:
-      dst-branch: "release-2.8"
+      dst-branch: "backplane-2.8"
     secrets:
       personal_access_token: ${{ secrets.GITHUB_TOKEN }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
-  call-sync-release-2_9:
+  call-sync-backplane-2_9:
     permissions:
       contents: write
       pull-requests: write
     uses: ./.github/workflows/sync-providers.yaml
     with:
-      dst-branch: "release-2.9"
+      dst-branch: "backplane-2.9"
     secrets:
       personal_access_token: ${{ secrets.GITHUB_TOKEN }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}


### PR DESCRIPTION
After removing release-* we need to skip them from syncing.