### PR TITLE
[backplane-2.9] fix: Let Go determine arch and os

### DIFF
--- a/mce-capi-webhook-config/Dockerfile
+++ b/mce-capi-webhook-config/Dockerfile
@@ -15,7 +15,7 @@ COPY main.go main.go
 COPY webhook/ webhook/
 
 # Build
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on GOEXPERIMENT=strictfipsruntime go build -a -o /tmp/mce-capi-webhook-config main.go
+RUN CGO_ENABLED=1 GO111MODULE=on GOEXPERIMENT=strictfipsruntime go build -a -o /tmp/mce-capi-webhook-config main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Multiarch is failing, I suspect it could be because GOOS and GOARCH are specified.

There is a temporary commit here to test the multiarch build.

ref: https://issues.redhat.com/browse/ACM-22055