### PR TITLE
Add repository url label to container images

### DIFF
--- a/mce-capi-webhook-config/Dockerfile
+++ b/mce-capi-webhook-config/Dockerfile
@@ -20,6 +20,7 @@ RUN CGO_ENABLED=1 GO111MODULE=on GOEXPERIMENT=strictfipsruntime go build -a -o /
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL com.redhat.component="" \
+      url="mce-capi-webhook-config/Dockerfile" \
       description="Auto-labeling CAPI resources based on openshift and hypershift namespaces" \
       io.k8s.description="Auto-labeling CAPI resources based on namespaces" \
       io.k8s.display-name="MultiCluster Engine CAPI Webhook Config" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** backplane-2.10

**Components affected:** cluster-api-webhook-config

**Branch details:** cluster-api-webhook-config (branch: backplane-2.10)

**Label added:**
- url: https://github.com/stolostron/cluster-api-installer

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.