### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cluster-api-webhook-config-mce-29

### DIFF
--- a/mce-capi-webhook-config/Dockerfile
+++ b/mce-capi-webhook-config/Dockerfile
@@ -20,11 +20,12 @@ RUN CGO_ENABLED=1 GO111MODULE=on GOEXPERIMENT=strictfipsruntime go build -a -o /
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL com.redhat.component="" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       description="Auto-labeling CAPI resources based on openshift and hypershift namespaces" \
       io.k8s.description="Auto-labeling CAPI resources based on namespaces" \
       io.k8s.display-name="MultiCluster Engine CAPI Webhook Config" \
       io.openshift.tags="cluster-api,capi,multicluster-engine" \
-      name="mce-capi-webhook-config" \
+      name="multicluster-engine/mce-capi-webhook-config-rhel9" \
       summary="Auto-labeling CAPI resources based on namespaces"
 
 WORKDIR /


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
