### PR TITLE
Update README to reflect all supported providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ CAPI components require the cert-manager operator to generate the necessary cert
 The cluster-api-installer syncs the changes from the upstream repos to the chart directory:
  * Core CAPI provider → `charts/cluster-api`
  * CAPA - AWS provider → `charts/cluster-api-provider-aws`
- * CAPZ - Azure provider → `charts/cluster-api-provider-azure`
  * CAPM3 - Metal3 provider → `charts/cluster-api-provider-metal3`
  * OpenShift Assisted provider → `charts/cluster-api-provider-openshift-assisted`
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Where:
   * `OCP_VERSION` ... the base for:
     * Controller image version - used in the Kubernetes deployment
     * Helm chart version (version in Chart.yaml)
-  * `*_BRANCH` ... the branch from which we will sync the changes for each provider
-  * `*_ORGREPO` ... source repository URLs
+  * `BRANCH` ... the branch from which we will sync the changes for each provider
+  * `ORGREPO` ... source repository URLs
 
 Then (for each provider project):
  1. The Git repository `$ORGREPO/$PROJECT` will be cloned into `out/$PROJECT`, and the `$BRANCH` will be checked out into the `out` temporary directory.

--- a/README.md
+++ b/README.md
@@ -2,32 +2,47 @@
 
 ## Introduction
 
-The Cluster-api-installer repository creates Helm charts for Cluster-API (CAPI) and its providers, such as Cluster-API-provider-AWS (CAPA), designed for deployment on OpenShift clusters. The MultiClusterEngine operator utilizes these Helm charts to deploy CAPI and CAPA as components of the MultiClusterEngine. For the upcoming release, the Cluster-api-installer repository will include Helm charts for additional Cluster-API providers, such as Cluster-API-provider-Azure (CAPZ) and Cluster-API-provider-Metal3 (CAPM).
+The Cluster-api-installer repository creates Helm charts for Cluster-API (CAPI) and its providers, designed for deployment on OpenShift clusters. The MultiClusterEngine operator utilizes these Helm charts to deploy CAPI and its providers as components of the MultiClusterEngine.
+
+Currently supported providers:
+ * Cluster-API-provider-AWS (CAPA)
+ * Cluster-API-provider-Azure (CAPZ)
+ * Cluster-API-provider-Metal3 (CAPM3)
+ * Cluster-API-provider-OpenShift-Assisted
 
 CAPI components require the cert-manager operator to generate the necessary certificates. The Cluster-api-installer modifies the CAPI Helm charts to leverage the cert-serve-service (certificate service) that already exists within the OpenShift cluster, instead of relying on the cert-manager operator.
 
 ## How it works
-The cluster-api-installer synch the changes happened in the openshift/cluser-api and openshift/cluster-api-provider-aws repos to the chart directory 
+The cluster-api-installer syncs the changes from the upstream repos to the chart directory:
  * Core CAPI provider → `charts/cluster-api`
  * CAPA - AWS provider → `charts/cluster-api-provider-aws`
+ * CAPZ - Azure provider → `charts/cluster-api-provider-azure`
+ * CAPM3 - Metal3 provider → `charts/cluster-api-provider-metal3`
+ * OpenShift Assisted provider → `charts/cluster-api-provider-openshift-assisted`
 
 The synchronization process synchronizes the Kubernetes deployment and creates a Helm chart (used for the Backplane Operator).
 
 The synchronizations are defined in `charts/Makefile`:
 ```make
-OCP_VERSION ?= 4.19
-BRANCH ?= master
-ORGREPO ?= https://github.com/openshift
+OCP_VERSION ?= 4.21
+DEFAULT_BRANCH ?= release-4.21
+CAPA_BRANCH ?= backplane-2.11
+CAPZ_BRANCH ?= backplane-2.11
+OPENSHIFT_ASSISTED_BRANCH ?= backplane-2.11
+METAL3_BRANCH ?= release-4.21
+DEFAULT_ORGREPO ?= https://github.com/openshift
+STOLOSTRON_ORGREPO ?= https://github.com/stolostron
+OPENSHIFT_ASSISTED_ORGREPO ?= https://github.com/openshift-assisted
 ```
 
 Where:
   * `OCP_VERSION` ... the base for:
     * Controller image version - used in the Kubernetes deployment
     * Helm chart version (version in Chart.yaml)
-  * `BRANCH` ... the branch from which we will sync the changes
-  * `ORGREPO` ... source repository URL
+  * `*_BRANCH` ... the branch from which we will sync the changes for each provider
+  * `*_ORGREPO` ... source repository URLs
 
-Then (for `PROJECT` in `cluster-api` `cluster-api-provider-aws`):
+Then (for each provider project):
  1. The Git repository `$ORGREPO/$PROJECT` will be cloned into `out/$PROJECT`, and the `$BRANCH` will be checked out into the `out` temporary directory.
  2. The `src/$PROJECT.yaml` file with the source objects (before transformation - see below) will be created.
  3. The synchronization of CRDs and Helm chart templates will begin, and the necessary files will be created/updated in the `charts/$PROJECT/crds` and `charts/$PROJECT/templates` directories.


### PR DESCRIPTION
## Summary
- Updated introduction to list all 4 currently supported providers (CAPA, CAPZ, CAPM3, OpenShift Assisted) instead of calling CAPZ and Metal3 "upcoming"
- Updated "How it works" section to include all 5 chart directories
- Updated Makefile config examples to match current values (OCP 4.21, per-provider branches, multiple org repos)
- Fixed typos ("synch" → "syncs", "cluser-api" → "cluster-api")

Related: #592 (sync-providers.yaml update)

## Test plan
- [ ] Review README rendering on GitHub
- [ ] Verify Makefile variables match `charts/Makefile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)