### PR TITLE
Fix CAPZ images and add imagePullSecret support

### DIFF
--- a/charts/cluster-api-provider-azure-kind/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/charts/cluster-api-provider-azure-kind/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -35,6 +35,7 @@ spec:
         - --crd-pattern={{ .Values.aso.crdPattern }}
         - --webhook-port=9443
         - --webhook-cert-dir=/tmp/k8s-webhook-server/serving-certs
+        - --crd-management=none
         env:
         - name: GOMEMLIMIT
           value: 400MiB

--- a/charts/cluster-api-provider-azure-kind/templates/v1_secret_capz-manager-pull-credentials.yaml
+++ b/charts/cluster-api-provider-azure-kind/templates/v1_secret_capz-manager-pull-credentials.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: '{{ .Values.imagePullSecret }}'
+kind: Secret
+metadata:
+  name: capz-manager-pull-credentials
+  namespace: capz-system
+type: kubernetes.io/dockerconfigjson

--- a/config-kind/cluster-api-provider-azure/base/capz-pull-secret.yaml
+++ b/config-kind/cluster-api-provider-azure/base/capz-pull-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capz-manager-pull-credentials
+  namespace: capz-system
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: '{{ .Values.imagePullSecret }}'

--- a/config-kind/cluster-api-provider-azure/kustomization.yaml
+++ b/config-kind/cluster-api-provider-azure/kustomization.yaml
@@ -37,6 +37,9 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/image
         value: '{{ .Values.aso.image.url  }}:{{ .Values.aso.image.tag  }}'
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --crd-management=none
   - target:
       kind: ServiceAccount
       name: capz-manager

--- a/replace-params
+++ b/replace-params
@@ -1,8 +1,8 @@
 declare -A helm_add_args_a=(
-  [capz]="--set manager.image.tag=2.17.0-c452227 --set aso.image.tag=2.17.0-d44e1f3"
-  [capa]="--set manager.image.url=quay.io/mveber/cluster-api-provider-aws-rhel9   --set manager.image.tag=latest"
+  [capi]="--set manager.image.url=quay.io/acm-d/ose-cluster-api-rhel9            --set webhook.image.url=quay.io/acm-d/mce-capi-webhook-config-rhel9 --set manager.image.tag=v4.22 --set webhook.image.tag=2.17.0-c19acd7"
+  [capz]="--set manager.image.url=quay.io/acm-d/cluster-api-provider-azure-rhel9 --set     aso.image.url=quay.io/acm-d/azure-service-operator-rhel9 --set manager.image.tag=2.17.0-c452227 --set aso.image.tag=2.17.0-dc98e44"
+  [capa]="--set manager.image.url=quay.io/acm-d/cluster-api-provider-aws-rhel9   --set manager.image.tag=latest"
   [capm3]="--set manager.image.url=quay.io/acm-d/ose-baremetal-cluster-api-controllers-rhel9"
 )
-#  [capi]="--set manager.image.url=quay.io/mveber/ose-cluster-api-rhel9            --set webhook.image.url=quay.io/mveber/mce-capi-webhook-config-rhel9 --set manager.image.tag=v4.22 --set webhook.image.tag=2.11.0-1"
 #  [capz]="--set manager.image.url=quay.io/mveber/cluster-api-provider-azure-rhel9 --set     aso.image.url=quay.io/mveber/azure-service-operator-rhel9  --set manager.image.tag=v2.17.0-10 --set aso.image.tag=v2.13.0-hcpclusters.9"
 


### PR DESCRIPTION
## Summary
- Add `imagePullSecret` support to CAPZ charts (pull secret resource, ServiceAccount patches), consistent with CAPI and CAPA charts
- Add `--crd-management=none` flag to ASO controller manager to disable CRD provisioning by ASO
- Use `eyJhdXRocyI6e319` (`{"auths":{}}`) as default `imagePullSecret` value — a no-op dockerconfigjson that works with public registries without requiring conditional Helm guards
- Update `replace-params` with correct image URLs from quay.io/acm-d

## Changes
- `config-kind/cluster-api-provider-azure/kustomization.yaml` — added pull secret resource, ServiceAccount imagePullSecrets patches, and `--crd-management=none` for ASO
- `config-kind/cluster-api-provider-azure/base/capz-pull-secret.yaml` — new pull secret resource
- `charts/cluster-api-provider-azure-kind/templates/v1_secret_capz-manager-pull-credentials.yaml` — new chart template
- `charts/cluster-api-provider-azure-kind/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml` — added `--crd-management=none`
- `replace-params` — updated image URLs and tags for local development

## Test plan
- [ ] Run `make build-helm-charts` and verify CAPZ chart templates include pull secret and ServiceAccount patches
- [ ] Deploy to k3s/kind cluster with default `imagePullSecret` (empty auth) and verify pods start successfully
- [ ] Deploy with real `imagePullSecret` override and verify private registry pull works

🤖 Generated with [Claude Code](https://claude.com/claude-code)