### PR TITLE
Fix cert-manager annotation in CAPA kind charts by removing hack.sh

### DIFF
--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsclusterroleidentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsclusterroleidentities.infrastructure.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmachines.infrastructure.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmachinetemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmachinetemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmanagedclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmanagedclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmanagedclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmanagedclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmanagedcontrolplanetemplates.controlplane.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_awsmanagedcontrolplanetemplates.controlplane.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_eksconfigs.bootstrap.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_eksconfigs.bootstrap.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_eksconfigtemplates.bootstrap.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_eksconfigtemplates.bootstrap.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_rosanetworks.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_rosanetworks.infrastructure.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_rosaroleconfigs.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-aws-kind/crds/apiextensions.k8s.io_v1_customresourcedefinition_rosaroleconfigs.infrastructure.cluster.x-k8s.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws

--- a/charts/cluster-api-provider-aws-kind/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_capa-mutating-webhook-configuration.yaml
+++ b/charts/cluster-api-provider-aws-kind/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_capa-mutating-webhook-configuration.yaml
@@ -2,7 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
   name: capa-mutating-webhook-configuration

--- a/charts/cluster-api-provider-aws-kind/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_capa-validating-webhook-configuration.yaml
+++ b/charts/cluster-api-provider-aws-kind/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_capa-validating-webhook-configuration.yaml
@@ -2,7 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
   name: capa-validating-webhook-configuration

--- a/charts/cluster-api-provider-aws-kind/values.yaml
+++ b/charts/cluster-api-provider-aws-kind/values.yaml
@@ -6,6 +6,6 @@ rosa:
 manager:
   cmd: /bin/cluster-api-provider-aws-controller-manager
   image:
-    tag: 2.17.0-aad0f9d
+    tag: 2.17.0-1
     url: quay.io/acm-d/cluster-api-provider-aws-rhel9
 imagePullSecret: "eyJhdXRocyI6e319"

--- a/charts/cluster-api-provider-aws-kind/values.yaml
+++ b/charts/cluster-api-provider-aws-kind/values.yaml
@@ -6,6 +6,6 @@ rosa:
 manager:
   cmd: /bin/cluster-api-provider-aws-controller-manager
   image:
-    tag: 2.17.0-1
+    tag: 2.17.0-674d6cb
     url: quay.io/acm-d/cluster-api-provider-aws-rhel9
 imagePullSecret: "eyJhdXRocyI6e319"

--- a/charts/cluster-api-provider-aws-kind/values.yaml
+++ b/charts/cluster-api-provider-aws-kind/values.yaml
@@ -6,6 +6,6 @@ rosa:
 manager:
   cmd: /bin/cluster-api-provider-aws-controller-manager
   image:
-    tag: 2.17.0-674d6cb
+    tag: 2.17.0-05bb875
     url: quay.io/acm-d/cluster-api-provider-aws-rhel9
 imagePullSecret: "eyJhdXRocyI6e319"

--- a/config-kind/cluster-api-provider-aws/hack.sh
+++ b/config-kind/cluster-api-provider-aws/hack.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -e
-SCRIPT_DIR=$(dirname "$0")
-${YQ} eval 'del(.vars[] | select(.name == "CERTIFICATE_NAME" or .name == "CERTIFICATE_NAMESPACE"))' "${SCRIPT_DIR}/default/kustomization.yaml" > "${SCRIPT_DIR}/default/kustomization.yaml.tmp"
-cp "${SCRIPT_DIR}/default/kustomization.yaml.tmp" "${SCRIPT_DIR}/default/kustomization.yaml"

--- a/src/cluster-api-provider-aws-kind.yaml
+++ b/src/cluster-api-provider-aws-kind.yaml
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -239,7 +239,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -587,7 +587,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -885,12 +885,10 @@ spec:
                           description: |-
                             IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.
                             A subnet can have an IPv4 and an IPv6 address.
-                            IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
                           type: string
                         isIpv6:
-                          description: |-
-                            IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.
-                            IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
+                          description: IsIPv6 defines the subnet as an IPv6 subnet.
+                            A subnet is IPv6 when it is associated with an IPv6 CIDR.
                           type: boolean
                         isPublic:
                           description: IsPublic defines the subnet as a public subnet.
@@ -952,9 +950,8 @@ spec:
                           associated with the VPC.
                         type: string
                       ipv6:
-                        description: |-
-                          IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.
-                          This field cannot be set on AWSCluster object.
+                        description: IPv6 contains ipv6 specific settings for the
+                          network.
                         properties:
                           cidrBlock:
                             description: CidrBlock is the CIDR block provided by Amazon
@@ -1503,9 +1500,13 @@ spec:
       name: Endpoint
       priority: 1
       type: string
-    - description: Bastion IP address for breakglass access
+    - description: Bastion IPv4 address for breakglass access
       jsonPath: .status.bastion.publicIp
       name: Bastion IP
+      type: string
+    - description: Bastion IPv6 address for breakglass access
+      jsonPath: .status.bastion.ipv6Address
+      name: Bastion IPv6
       type: string
     name: v1beta2
     schema:
@@ -1548,6 +1549,7 @@ spec:
                     description: |-
                       AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.
                       They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).
+                      If the cluster has IPv6 enabled, defaults to ::/0 and 0.0.0.0/0.
                     items:
                       type: string
                     type: array
@@ -1671,6 +1673,16 @@ spec:
                             Currently only TCP is supported.
                           enum:
                           - TCP
+                          type: string
+                        targetGroupIPType:
+                          description: |-
+                            TargetGroupIPType sets the IP address type for the target group.
+                            Valid values are ipv4 and ipv6. If not specified, defaults to ipv4 unless
+                            the VPC has IPv6 enabled, in which case it defaults to ipv6.
+                            This field cannot be set if LoadBalancerType is classic or disabled.
+                          enum:
+                          - ipv4
+                          - ipv6
                           type: string
                       required:
                       - port
@@ -1868,6 +1880,17 @@ spec:
                     items:
                       type: string
                     type: array
+                  targetGroupIPType:
+                    description: |-
+                      TargetGroupIPType sets the IP address type for the target group.
+                      Valid values are ipv4 and ipv6. If not specified, defaults to ipv4 unless
+                      the VPC has IPv6 enabled, in which case it defaults to ipv6.
+                      This applies to the API server target group.
+                      This field cannot be set if LoadBalancerType is classic or disabled.
+                    enum:
+                    - ipv4
+                    - ipv6
+                    type: string
                 type: object
               identityRef:
                 description: |-
@@ -2147,12 +2170,10 @@ spec:
                           description: |-
                             IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.
                             A subnet can have an IPv4 and an IPv6 address.
-                            IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
                           type: string
                         isIpv6:
-                          description: |-
-                            IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.
-                            IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
+                          description: IsIPv6 defines the subnet as an IPv6 subnet.
+                            A subnet is IPv6 when it is associated with an IPv6 CIDR.
                           type: boolean
                         isPublic:
                           description: IsPublic defines the subnet as a public subnet.
@@ -2329,13 +2350,13 @@ spec:
                               The netmask length of the IPv4 CIDR you want to allocate to VPC from
                               an Amazon VPC IP Address Manager (IPAM) pool.
                               Defaults to /16 for IPv4 if not specified.
+                              Defaults to /56 for IPv6 if not specified.
                             format: int64
                             type: integer
                         type: object
                       ipv6:
-                        description: |-
-                          IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.
-                          This field cannot be set on AWSCluster object.
+                        description: IPv6 contains ipv6 specific settings for the
+                          network.
                         properties:
                           cidrBlock:
                             description: |-
@@ -2365,6 +2386,7 @@ spec:
                                   The netmask length of the IPv4 CIDR you want to allocate to VPC from
                                   an Amazon VPC IP Address Manager (IPAM) pool.
                                   Defaults to /16 for IPv4 if not specified.
+                                  Defaults to /56 for IPv6 if not specified.
                                 format: int64
                                 type: integer
                             type: object
@@ -2555,6 +2577,16 @@ spec:
                             Currently only TCP is supported.
                           enum:
                           - TCP
+                          type: string
+                        targetGroupIPType:
+                          description: |-
+                            TargetGroupIPType sets the IP address type for the target group.
+                            Valid values are ipv4 and ipv6. If not specified, defaults to ipv4 unless
+                            the VPC has IPv6 enabled, in which case it defaults to ipv6.
+                            This field cannot be set if LoadBalancerType is classic or disabled.
+                          enum:
+                          - ipv4
+                          - ipv6
                           type: string
                       required:
                       - port
@@ -2752,6 +2784,17 @@ spec:
                     items:
                       type: string
                     type: array
+                  targetGroupIPType:
+                    description: |-
+                      TargetGroupIPType sets the IP address type for the target group.
+                      Valid values are ipv4 and ipv6. If not specified, defaults to ipv4 unless
+                      the VPC has IPv6 enabled, in which case it defaults to ipv6.
+                      This applies to the API server target group.
+                      This field cannot be set if LoadBalancerType is classic or disabled.
+                    enum:
+                    - ipv4
+                    - ipv6
+                    type: string
                 type: object
               sshKeyName:
                 description: SSHKeyName is the name of the ssh key to attach to the
@@ -2791,6 +2834,10 @@ spec:
                       - type
                       type: object
                     type: array
+                  assignPrimaryIPv6:
+                    description: AssignPrimaryIPv6 specifies whether to enable assigning
+                      a primary IPv6 address to the primary network Interface.
+                    type: string
                   availabilityZone:
                     description: Availability zone of instance
                     type: string
@@ -2839,6 +2886,15 @@ spec:
                         enum:
                         - Disabled
                         - AMDEncryptedVirtualizationNestedPaging
+                        type: string
+                      nestedVirtualization:
+                        description: |-
+                          NestedVirtualization specifies whether to enable nested virtualization on the instance.
+                          Nested virtualization is supported on C8i, M8i, and R8i instance types.
+                          Valid values are: enabled, disabled
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                     type: object
                   dynamicHostAllocation:
@@ -2902,6 +2958,17 @@ spec:
                         - enabled
                         - disabled
                         type: string
+                      httpProtocolIpv6:
+                        default: disabled
+                        description: |-
+                          Enables or disables the IPv6 endpoint for the instance metadata service.
+                          This applies only if you enabled the HTTP metadata endpoint.
+
+                          Default: disabled
+                        enum:
+                        - enabled
+                        - disabled
+                        type: string
                       httpPutResponseHopLimit:
                         default: 1
                         description: |-
@@ -2950,6 +3017,9 @@ spec:
                     type: object
                   instanceState:
                     description: The current state of the instance.
+                    type: string
+                  ipv6Address:
+                    description: The IPv6 address assigned to the instance.
                     type: string
                   marketType:
                     description: |-
@@ -3279,6 +3349,10 @@ spec:
                                 TargetGroupSpec specifies target group settings for a given listener.
                                 This is created first, and the ARN is then passed to the listener.
                               properties:
+                                ipType:
+                                  description: IPType is the IP address type for the
+                                    target group.
+                                  type: string
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
@@ -3398,6 +3472,14 @@ spec:
                           - protocol
                           type: object
                         type: array
+                      loadBalancerIPAddressType:
+                        description: LoadBalancerIPAddressType specifies the IP address
+                          type for the load balancer.
+                        enum:
+                        - ipv4
+                        - dualstack
+                        - dualstack-without-public-ipv4
+                        type: string
                       loadBalancerType:
                         description: LoadBalancerType sets the type for a load balancer.
                           The default type is classic.
@@ -3499,6 +3581,10 @@ spec:
                                 TargetGroupSpec specifies target group settings for a given listener.
                                 This is created first, and the ARN is then passed to the listener.
                               properties:
+                                ipType:
+                                  description: IPType is the IP address type for the
+                                    target group.
+                                  type: string
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
@@ -3618,6 +3704,14 @@ spec:
                           - protocol
                           type: object
                         type: array
+                      loadBalancerIPAddressType:
+                        description: LoadBalancerIPAddressType specifies the IP address
+                          type for the load balancer.
+                        enum:
+                        - ipv4
+                        - dualstack
+                        - dualstack-without-public-ipv4
+                        type: string
                       loadBalancerType:
                         description: LoadBalancerType sets the type for a load balancer.
                           The default type is classic.
@@ -4011,7 +4105,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -4328,12 +4422,11 @@ spec:
                                   description: |-
                                     IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.
                                     A subnet can have an IPv4 and an IPv6 address.
-                                    IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
                                   type: string
                                 isIpv6:
-                                  description: |-
-                                    IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.
-                                    IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
+                                  description: IsIPv6 defines the subnet as an IPv6
+                                    subnet. A subnet is IPv6 when it is associated
+                                    with an IPv6 CIDR.
                                   type: boolean
                                 isPublic:
                                   description: IsPublic defines the subnet as a public
@@ -4396,9 +4489,8 @@ spec:
                                   gateway associated with the VPC.
                                 type: string
                               ipv6:
-                                description: |-
-                                  IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.
-                                  This field cannot be set on AWSCluster object.
+                                description: IPv6 contains ipv6 specific settings
+                                  for the network.
                                 properties:
                                   cidrBlock:
                                     description: CidrBlock is the CIDR block provided
@@ -4550,6 +4642,7 @@ spec:
                             description: |-
                               AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.
                               They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).
+                              If the cluster has IPv6 enabled, defaults to ::/0 and 0.0.0.0/0.
                             items:
                               type: string
                             type: array
@@ -4676,6 +4769,16 @@ spec:
                                     Currently only TCP is supported.
                                   enum:
                                   - TCP
+                                  type: string
+                                targetGroupIPType:
+                                  description: |-
+                                    TargetGroupIPType sets the IP address type for the target group.
+                                    Valid values are ipv4 and ipv6. If not specified, defaults to ipv4 unless
+                                    the VPC has IPv6 enabled, in which case it defaults to ipv6.
+                                    This field cannot be set if LoadBalancerType is classic or disabled.
+                                  enum:
+                                  - ipv4
+                                  - ipv6
                                   type: string
                               required:
                               - port
@@ -4875,6 +4978,17 @@ spec:
                             items:
                               type: string
                             type: array
+                          targetGroupIPType:
+                            description: |-
+                              TargetGroupIPType sets the IP address type for the target group.
+                              Valid values are ipv4 and ipv6. If not specified, defaults to ipv4 unless
+                              the VPC has IPv6 enabled, in which case it defaults to ipv6.
+                              This applies to the API server target group.
+                              This field cannot be set if LoadBalancerType is classic or disabled.
+                            enum:
+                            - ipv4
+                            - ipv6
+                            type: string
                         type: object
                       identityRef:
                         description: |-
@@ -5158,12 +5272,11 @@ spec:
                                   description: |-
                                     IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.
                                     A subnet can have an IPv4 and an IPv6 address.
-                                    IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
                                   type: string
                                 isIpv6:
-                                  description: |-
-                                    IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.
-                                    IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
+                                  description: IsIPv6 defines the subnet as an IPv6
+                                    subnet. A subnet is IPv6 when it is associated
+                                    with an IPv6 CIDR.
                                   type: boolean
                                 isPublic:
                                   description: IsPublic defines the subnet as a public
@@ -5341,13 +5454,13 @@ spec:
                                       The netmask length of the IPv4 CIDR you want to allocate to VPC from
                                       an Amazon VPC IP Address Manager (IPAM) pool.
                                       Defaults to /16 for IPv4 if not specified.
+                                      Defaults to /56 for IPv6 if not specified.
                                     format: int64
                                     type: integer
                                 type: object
                               ipv6:
-                                description: |-
-                                  IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.
-                                  This field cannot be set on AWSCluster object.
+                                description: IPv6 contains ipv6 specific settings
+                                  for the network.
                                 properties:
                                   cidrBlock:
                                     description: |-
@@ -5378,6 +5491,7 @@ spec:
                                           The netmask length of the IPv4 CIDR you want to allocate to VPC from
                                           an Amazon VPC IP Address Manager (IPAM) pool.
                                           Defaults to /16 for IPv4 if not specified.
+                                          Defaults to /56 for IPv6 if not specified.
                                         format: int64
                                         type: integer
                                     type: object
@@ -5570,6 +5684,16 @@ spec:
                                     Currently only TCP is supported.
                                   enum:
                                   - TCP
+                                  type: string
+                                targetGroupIPType:
+                                  description: |-
+                                    TargetGroupIPType sets the IP address type for the target group.
+                                    Valid values are ipv4 and ipv6. If not specified, defaults to ipv4 unless
+                                    the VPC has IPv6 enabled, in which case it defaults to ipv6.
+                                    This field cannot be set if LoadBalancerType is classic or disabled.
+                                  enum:
+                                  - ipv4
+                                  - ipv6
                                   type: string
                               required:
                               - port
@@ -5769,6 +5893,17 @@ spec:
                             items:
                               type: string
                             type: array
+                          targetGroupIPType:
+                            description: |-
+                              TargetGroupIPType sets the IP address type for the target group.
+                              Valid values are ipv4 and ipv6. If not specified, defaults to ipv4 unless
+                              the VPC has IPv6 enabled, in which case it defaults to ipv6.
+                              This applies to the API server target group.
+                              This field cannot be set if LoadBalancerType is classic or disabled.
+                            enum:
+                            - ipv4
+                            - ipv6
+                            type: string
                         type: object
                       sshKeyName:
                         description: SSHKeyName is the name of the ssh key to attach
@@ -6936,6 +7071,17 @@ spec:
                         - enabled
                         - disabled
                         type: string
+                      httpProtocolIpv6:
+                        default: disabled
+                        description: |-
+                          Enables or disables the IPv6 endpoint for the instance metadata service.
+                          This applies only if you enabled the HTTP metadata endpoint.
+
+                          Default: disabled
+                        enum:
+                        - enabled
+                        - disabled
+                        type: string
                       httpPutResponseHopLimit:
                         default: 1
                         description: |-
@@ -7616,7 +7762,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -8269,6 +8415,19 @@ spec:
                     description: ID of resource
                     type: string
                 type: object
+              assignPrimaryIPv6:
+                description: |-
+                  AssignPrimaryIPv6 specifies whether to enable assigning a primary IPv6 address to the primary network Interface.
+                  When set to enabled, the instance will be assigned a primary IPv6 address from the subnet's IPv6 CIDR block.
+                  This is required when registering instances by ID to IPv6 target groups of dual-stack load balancers.
+
+                  When not specified, the default value varies based on the subnet that the instance is launched in:
+                  - disabled if subnet is ipv4 only
+                  - enabled if subnet is ipv6 only or dual-stack
+                enum:
+                - enabled
+                - disabled
+                type: string
               capacityReservationId:
                 description: CapacityReservationID specifies the target Capacity Reservation
                   into which the instance should be launched.
@@ -8347,6 +8506,15 @@ spec:
                     enum:
                     - Disabled
                     - AMDEncryptedVirtualizationNestedPaging
+                    type: string
+                  nestedVirtualization:
+                    description: |-
+                      NestedVirtualization specifies whether to enable nested virtualization on the instance.
+                      Nested virtualization is supported on C8i, M8i, and R8i instance types.
+                      Valid values are: enabled, disabled
+                    enum:
+                    - enabled
+                    - disabled
                     type: string
                 type: object
               dynamicHostAllocation:
@@ -8551,6 +8719,17 @@ spec:
                       If you specify a value of disabled, you cannot access your instance metadata.
 
                       Default: enabled
+                    enum:
+                    - enabled
+                    - disabled
+                    type: string
+                  httpProtocolIpv6:
+                    default: disabled
+                    description: |-
+                      Enables or disables the IPv6 endpoint for the instance metadata service.
+                      This applies only if you enabled the HTTP metadata endpoint.
+
+                      Default: disabled
                     enum:
                     - enabled
                     - disabled
@@ -8996,7 +9175,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -9568,6 +9747,19 @@ spec:
                             description: ID of resource
                             type: string
                         type: object
+                      assignPrimaryIPv6:
+                        description: |-
+                          AssignPrimaryIPv6 specifies whether to enable assigning a primary IPv6 address to the primary network Interface.
+                          When set to enabled, the instance will be assigned a primary IPv6 address from the subnet's IPv6 CIDR block.
+                          This is required when registering instances by ID to IPv6 target groups of dual-stack load balancers.
+
+                          When not specified, the default value varies based on the subnet that the instance is launched in:
+                          - disabled if subnet is ipv4 only
+                          - enabled if subnet is ipv6 only or dual-stack
+                        enum:
+                        - enabled
+                        - disabled
+                        type: string
                       capacityReservationId:
                         description: CapacityReservationID specifies the target Capacity
                           Reservation into which the instance should be launched.
@@ -9646,6 +9838,15 @@ spec:
                             enum:
                             - Disabled
                             - AMDEncryptedVirtualizationNestedPaging
+                            type: string
+                          nestedVirtualization:
+                            description: |-
+                              NestedVirtualization specifies whether to enable nested virtualization on the instance.
+                              Nested virtualization is supported on C8i, M8i, and R8i instance types.
+                              Valid values are: enabled, disabled
+                            enum:
+                            - enabled
+                            - disabled
                             type: string
                         type: object
                       dynamicHostAllocation:
@@ -9851,6 +10052,17 @@ spec:
                               If you specify a value of disabled, you cannot access your instance metadata.
 
                               Default: enabled
+                            enum:
+                            - enabled
+                            - disabled
+                            type: string
+                          httpProtocolIpv6:
+                            default: disabled
+                            description: |-
+                              Enables or disables the IPv6 endpoint for the instance metadata service.
+                              This applies only if you enabled the HTTP metadata endpoint.
+
+                              Default: disabled
                             enum:
                             - enabled
                             - disabled
@@ -10258,7 +10470,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -10425,7 +10637,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -10514,7 +10726,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -10654,6 +10866,7 @@ spec:
                     description: |-
                       AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.
                       They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).
+                      If the cluster has IPv6 enabled, defaults to ::/0 and 0.0.0.0/0.
                     items:
                       type: string
                     type: array
@@ -11127,12 +11340,10 @@ spec:
                           description: |-
                             IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.
                             A subnet can have an IPv4 and an IPv6 address.
-                            IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
                           type: string
                         isIpv6:
-                          description: |-
-                            IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.
-                            IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
+                          description: IsIPv6 defines the subnet as an IPv6 subnet.
+                            A subnet is IPv6 when it is associated with an IPv6 CIDR.
                           type: boolean
                         isPublic:
                           description: IsPublic defines the subnet as a public subnet.
@@ -11309,13 +11520,13 @@ spec:
                               The netmask length of the IPv4 CIDR you want to allocate to VPC from
                               an Amazon VPC IP Address Manager (IPAM) pool.
                               Defaults to /16 for IPv4 if not specified.
+                              Defaults to /56 for IPv6 if not specified.
                             format: int64
                             type: integer
                         type: object
                       ipv6:
-                        description: |-
-                          IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.
-                          This field cannot be set on AWSCluster object.
+                        description: IPv6 contains ipv6 specific settings for the
+                          network.
                         properties:
                           cidrBlock:
                             description: |-
@@ -11345,6 +11556,7 @@ spec:
                                   The netmask length of the IPv4 CIDR you want to allocate to VPC from
                                   an Amazon VPC IP Address Manager (IPAM) pool.
                                   Defaults to /16 for IPv4 if not specified.
+                                  Defaults to /56 for IPv6 if not specified.
                                 format: int64
                                 type: integer
                             type: object
@@ -11740,6 +11952,10 @@ spec:
                       - type
                       type: object
                     type: array
+                  assignPrimaryIPv6:
+                    description: AssignPrimaryIPv6 specifies whether to enable assigning
+                      a primary IPv6 address to the primary network Interface.
+                    type: string
                   availabilityZone:
                     description: Availability zone of instance
                     type: string
@@ -11788,6 +12004,15 @@ spec:
                         enum:
                         - Disabled
                         - AMDEncryptedVirtualizationNestedPaging
+                        type: string
+                      nestedVirtualization:
+                        description: |-
+                          NestedVirtualization specifies whether to enable nested virtualization on the instance.
+                          Nested virtualization is supported on C8i, M8i, and R8i instance types.
+                          Valid values are: enabled, disabled
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                     type: object
                   dynamicHostAllocation:
@@ -11851,6 +12076,17 @@ spec:
                         - enabled
                         - disabled
                         type: string
+                      httpProtocolIpv6:
+                        default: disabled
+                        description: |-
+                          Enables or disables the IPv6 endpoint for the instance metadata service.
+                          This applies only if you enabled the HTTP metadata endpoint.
+
+                          Default: disabled
+                        enum:
+                        - enabled
+                        - disabled
+                        type: string
                       httpPutResponseHopLimit:
                         default: 1
                         description: |-
@@ -11899,6 +12135,9 @@ spec:
                     type: object
                   instanceState:
                     description: The current state of the instance.
+                    type: string
+                  ipv6Address:
+                    description: The IPv6 address assigned to the instance.
                     type: string
                   marketType:
                     description: |-
@@ -12259,6 +12498,10 @@ spec:
                                 TargetGroupSpec specifies target group settings for a given listener.
                                 This is created first, and the ARN is then passed to the listener.
                               properties:
+                                ipType:
+                                  description: IPType is the IP address type for the
+                                    target group.
+                                  type: string
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
@@ -12378,6 +12621,14 @@ spec:
                           - protocol
                           type: object
                         type: array
+                      loadBalancerIPAddressType:
+                        description: LoadBalancerIPAddressType specifies the IP address
+                          type for the load balancer.
+                        enum:
+                        - ipv4
+                        - dualstack
+                        - dualstack-without-public-ipv4
+                        type: string
                       loadBalancerType:
                         description: LoadBalancerType sets the type for a load balancer.
                           The default type is classic.
@@ -12479,6 +12730,10 @@ spec:
                                 TargetGroupSpec specifies target group settings for a given listener.
                                 This is created first, and the ARN is then passed to the listener.
                               properties:
+                                ipType:
+                                  description: IPType is the IP address type for the
+                                    target group.
+                                  type: string
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
@@ -12598,6 +12853,14 @@ spec:
                           - protocol
                           type: object
                         type: array
+                      loadBalancerIPAddressType:
+                        description: LoadBalancerIPAddressType specifies the IP address
+                          type for the load balancer.
+                        enum:
+                        - ipv4
+                        - dualstack
+                        - dualstack-without-public-ipv4
+                        type: string
                       loadBalancerType:
                         description: LoadBalancerType sets the type for a load balancer.
                           The default type is classic.
@@ -12834,6 +13097,85 @@ spec:
                       ignored when updating existing clusters. Defaults to true.
                     type: boolean
                 type: object
+              accessEntries:
+                description: |-
+                  AccessEntries specifies the access entries for the cluster
+                  Access entries require AuthenticationMode to be either "api" or "api_and_config_map"
+                items:
+                  description: AccessEntry represents an AWS EKS access entry for
+                    IAM principals
+                  properties:
+                    accessPolicies:
+                      description: |-
+                        AccessPolicies specifies the policies to associate with this access entry
+                        Cannot be specified if Type is "ec2_linux" or "ec2_windows"
+                      items:
+                        description: AccessPolicyReference represents a reference
+                          to an AWS EKS access policy
+                        properties:
+                          accessScope:
+                            description: AccessScope specifies the scope for the policy
+                            properties:
+                              namespaces:
+                                description: |-
+                                  Namespaces are the namespaces for the access scope
+                                  Only valid when Type is namespace
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                              type:
+                                default: cluster
+                                description: Type is the type of access scope. Defaults
+                                  to "cluster".
+                                enum:
+                                - cluster
+                                - namespace
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          policyARN:
+                            description: PolicyARN is the Amazon Resource Name (ARN)
+                              of the access policy
+                            type: string
+                        required:
+                        - accessScope
+                        - policyARN
+                        type: object
+                      maxItems: 20
+                      type: array
+                    kubernetesGroups:
+                      description: |-
+                        KubernetesGroups represents the Kubernetes groups for the access entry
+                        Cannot be specified if Type is "ec2_linux" or "ec2_windows"
+                      items:
+                        type: string
+                      type: array
+                    principalARN:
+                      description: PrincipalARN is the Amazon Resource Name (ARN)
+                        of the IAM principal
+                      type: string
+                    type:
+                      default: standard
+                      description: Type is the type of access entry. Defaults to standard
+                        if not specified.
+                      enum:
+                      - standard
+                      - ec2_linux
+                      - ec2_windows
+                      - fargate_linux
+                      - ec2
+                      - hybrid_linux
+                      - hyperpod_linux
+                      type: string
+                    username:
+                      description: Username is the username for the access entry
+                      type: string
+                  required:
+                  - principalARN
+                  type: object
+                type: array
               additionalTags:
                 additionalProperties:
                   type: string
@@ -12894,6 +13236,7 @@ spec:
                     description: |-
                       AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.
                       They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).
+                      If the cluster has IPv6 enabled, defaults to ::/0 and 0.0.0.0/0.
                     items:
                       type: string
                     type: array
@@ -13365,12 +13708,10 @@ spec:
                           description: |-
                             IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.
                             A subnet can have an IPv4 and an IPv6 address.
-                            IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
                           type: string
                         isIpv6:
-                          description: |-
-                            IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.
-                            IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
+                          description: IsIPv6 defines the subnet as an IPv6 subnet.
+                            A subnet is IPv6 when it is associated with an IPv6 CIDR.
                           type: boolean
                         isPublic:
                           description: IsPublic defines the subnet as a public subnet.
@@ -13547,13 +13888,13 @@ spec:
                               The netmask length of the IPv4 CIDR you want to allocate to VPC from
                               an Amazon VPC IP Address Manager (IPAM) pool.
                               Defaults to /16 for IPv4 if not specified.
+                              Defaults to /56 for IPv6 if not specified.
                             format: int64
                             type: integer
                         type: object
                       ipv6:
-                        description: |-
-                          IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.
-                          This field cannot be set on AWSCluster object.
+                        description: IPv6 contains ipv6 specific settings for the
+                          network.
                         properties:
                           cidrBlock:
                             description: |-
@@ -13583,6 +13924,7 @@ spec:
                                   The netmask length of the IPv4 CIDR you want to allocate to VPC from
                                   an Amazon VPC IP Address Manager (IPAM) pool.
                                   Defaults to /16 for IPv4 if not specified.
+                                  Defaults to /56 for IPv6 if not specified.
                                 format: int64
                                 type: integer
                             type: object
@@ -14031,6 +14373,10 @@ spec:
                       - type
                       type: object
                     type: array
+                  assignPrimaryIPv6:
+                    description: AssignPrimaryIPv6 specifies whether to enable assigning
+                      a primary IPv6 address to the primary network Interface.
+                    type: string
                   availabilityZone:
                     description: Availability zone of instance
                     type: string
@@ -14079,6 +14425,15 @@ spec:
                         enum:
                         - Disabled
                         - AMDEncryptedVirtualizationNestedPaging
+                        type: string
+                      nestedVirtualization:
+                        description: |-
+                          NestedVirtualization specifies whether to enable nested virtualization on the instance.
+                          Nested virtualization is supported on C8i, M8i, and R8i instance types.
+                          Valid values are: enabled, disabled
+                        enum:
+                        - enabled
+                        - disabled
                         type: string
                     type: object
                   dynamicHostAllocation:
@@ -14142,6 +14497,17 @@ spec:
                         - enabled
                         - disabled
                         type: string
+                      httpProtocolIpv6:
+                        default: disabled
+                        description: |-
+                          Enables or disables the IPv6 endpoint for the instance metadata service.
+                          This applies only if you enabled the HTTP metadata endpoint.
+
+                          Default: disabled
+                        enum:
+                        - enabled
+                        - disabled
+                        type: string
                       httpPutResponseHopLimit:
                         default: 1
                         description: |-
@@ -14190,6 +14556,9 @@ spec:
                     type: object
                   instanceState:
                     description: The current state of the instance.
+                    type: string
+                  ipv6Address:
+                    description: The IPv6 address assigned to the instance.
                     type: string
                   marketType:
                     description: |-
@@ -14550,6 +14919,10 @@ spec:
                                 TargetGroupSpec specifies target group settings for a given listener.
                                 This is created first, and the ARN is then passed to the listener.
                               properties:
+                                ipType:
+                                  description: IPType is the IP address type for the
+                                    target group.
+                                  type: string
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
@@ -14669,6 +15042,14 @@ spec:
                           - protocol
                           type: object
                         type: array
+                      loadBalancerIPAddressType:
+                        description: LoadBalancerIPAddressType specifies the IP address
+                          type for the load balancer.
+                        enum:
+                        - ipv4
+                        - dualstack
+                        - dualstack-without-public-ipv4
+                        type: string
                       loadBalancerType:
                         description: LoadBalancerType sets the type for a load balancer.
                           The default type is classic.
@@ -14770,6 +15151,10 @@ spec:
                                 TargetGroupSpec specifies target group settings for a given listener.
                                 This is created first, and the ARN is then passed to the listener.
                               properties:
+                                ipType:
+                                  description: IPType is the IP address type for the
+                                    target group.
+                                  type: string
                                 name:
                                   description: Name of the TargetGroup. Must be unique
                                     over the same group of listeners.
@@ -14889,6 +15274,14 @@ spec:
                           - protocol
                           type: object
                         type: array
+                      loadBalancerIPAddressType:
+                        description: LoadBalancerIPAddressType specifies the IP address
+                          type for the load balancer.
+                        enum:
+                        - ipv4
+                        - dualstack
+                        - dualstack-without-public-ipv4
+                        type: string
                       loadBalancerType:
                         description: LoadBalancerType sets the type for a load balancer.
                           The default type is classic.
@@ -15064,7 +15457,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -15153,6 +15546,87 @@ spec:
                               ignored when updating existing clusters. Defaults to true.
                             type: boolean
                         type: object
+                      accessEntries:
+                        description: |-
+                          AccessEntries specifies the access entries for the cluster
+                          Access entries require AuthenticationMode to be either "api" or "api_and_config_map"
+                        items:
+                          description: AccessEntry represents an AWS EKS access entry
+                            for IAM principals
+                          properties:
+                            accessPolicies:
+                              description: |-
+                                AccessPolicies specifies the policies to associate with this access entry
+                                Cannot be specified if Type is "ec2_linux" or "ec2_windows"
+                              items:
+                                description: AccessPolicyReference represents a reference
+                                  to an AWS EKS access policy
+                                properties:
+                                  accessScope:
+                                    description: AccessScope specifies the scope for
+                                      the policy
+                                    properties:
+                                      namespaces:
+                                        description: |-
+                                          Namespaces are the namespaces for the access scope
+                                          Only valid when Type is namespace
+                                        items:
+                                          type: string
+                                        minItems: 1
+                                        type: array
+                                      type:
+                                        default: cluster
+                                        description: Type is the type of access scope.
+                                          Defaults to "cluster".
+                                        enum:
+                                        - cluster
+                                        - namespace
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  policyARN:
+                                    description: PolicyARN is the Amazon Resource
+                                      Name (ARN) of the access policy
+                                    type: string
+                                required:
+                                - accessScope
+                                - policyARN
+                                type: object
+                              maxItems: 20
+                              type: array
+                            kubernetesGroups:
+                              description: |-
+                                KubernetesGroups represents the Kubernetes groups for the access entry
+                                Cannot be specified if Type is "ec2_linux" or "ec2_windows"
+                              items:
+                                type: string
+                              type: array
+                            principalARN:
+                              description: PrincipalARN is the Amazon Resource Name
+                                (ARN) of the IAM principal
+                              type: string
+                            type:
+                              default: standard
+                              description: Type is the type of access entry. Defaults
+                                to standard if not specified.
+                              enum:
+                              - standard
+                              - ec2_linux
+                              - ec2_windows
+                              - fargate_linux
+                              - ec2
+                              - hybrid_linux
+                              - hyperpod_linux
+                              type: string
+                            username:
+                              description: Username is the username for the access
+                                entry
+                              type: string
+                          required:
+                          - principalARN
+                          type: object
+                        type: array
                       additionalTags:
                         additionalProperties:
                           type: string
@@ -15215,6 +15689,7 @@ spec:
                             description: |-
                               AllowedCIDRBlocks is a list of CIDR blocks allowed to access the bastion host.
                               They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0).
+                              If the cluster has IPv6 enabled, defaults to ::/0 and 0.0.0.0/0.
                             items:
                               type: string
                             type: array
@@ -15698,12 +16173,11 @@ spec:
                                   description: |-
                                     IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC.
                                     A subnet can have an IPv4 and an IPv6 address.
-                                    IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
                                   type: string
                                 isIpv6:
-                                  description: |-
-                                    IsIPv6 defines the subnet as an IPv6 subnet. A subnet is IPv6 when it is associated with a VPC that has IPv6 enabled.
-                                    IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
+                                  description: IsIPv6 defines the subnet as an IPv6
+                                    subnet. A subnet is IPv6 when it is associated
+                                    with an IPv6 CIDR.
                                   type: boolean
                                 isPublic:
                                   description: IsPublic defines the subnet as a public
@@ -15881,13 +16355,13 @@ spec:
                                       The netmask length of the IPv4 CIDR you want to allocate to VPC from
                                       an Amazon VPC IP Address Manager (IPAM) pool.
                                       Defaults to /16 for IPv4 if not specified.
+                                      Defaults to /56 for IPv6 if not specified.
                                     format: int64
                                     type: integer
                                 type: object
                               ipv6:
-                                description: |-
-                                  IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters.
-                                  This field cannot be set on AWSCluster object.
+                                description: IPv6 contains ipv6 specific settings
+                                  for the network.
                                 properties:
                                   cidrBlock:
                                     description: |-
@@ -15918,6 +16392,7 @@ spec:
                                           The netmask length of the IPv4 CIDR you want to allocate to VPC from
                                           an Amazon VPC IP Address Manager (IPAM) pool.
                                           Defaults to /16 for IPv4 if not specified.
+                                          Defaults to /56 for IPv6 if not specified.
                                         format: int64
                                         type: integer
                                     type: object
@@ -17010,6 +17485,17 @@ spec:
                         - enabled
                         - disabled
                         type: string
+                      httpProtocolIpv6:
+                        default: disabled
+                        description: |-
+                          Enables or disables the IPv6 endpoint for the instance metadata service.
+                          This applies only if you enabled the HTTP metadata endpoint.
+
+                          Default: disabled
+                        enum:
+                        - enabled
+                        - disabled
+                        type: string
                       httpPutResponseHopLimit:
                         default: 1
                         description: |-
@@ -17545,7 +18031,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -17753,8 +18239,12 @@ spec:
     name: v1beta2
     schema:
       openAPIV3Schema:
-        description: EKSConfig is the schema for the Amazon EKS Machine Bootstrap
-          Configuration API.
+        description: |-
+          EKSConfig is the schema for the Amazon EKS Machine Bootstrap Configuration API.
+
+          Deprecated: EKSConfig is deprecated and will be removed in a future release.
+          Amazon Linux 2 (AL2) reaches end-of-life in June 2026 see: https://aws.amazon.com/amazon-linux-2/faqs/
+          Please use NodeadmConfig with Amazon Linux 2023 (AL2023) instead.
         properties:
           apiVersion:
             description: |-
@@ -18153,7 +18643,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -18629,6 +19119,760 @@ metadata:
     cluster.x-k8s.io/v1alpha3: v1alpha3
     cluster.x-k8s.io/v1alpha4: v1alpha4
     cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
+  name: nodeadmconfigs.bootstrap.cluster.x-k8s.io
+spec:
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    kind: NodeadmConfig
+    listKind: NodeadmConfigList
+    plural: nodeadmconfigs
+    singular: nodeadmconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: NodeadmConfig is the Schema for the nodeadmconfigs API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeadmConfigSpec defines the desired state of NodeadmConfig.
+            properties:
+              containerd:
+                description: Containerd contains options for containerd.
+                properties:
+                  baseRuntimeSpec:
+                    description: BaseRuntimeSpec is the OCI runtime specification
+                      upon which all containers will be based.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  config:
+                    description: Config is an inline containerd configuration TOML
+                      that will be merged with the defaults.
+                    type: string
+                type: object
+              diskSetup:
+                description: DiskSetup specifies options for the creation of partition
+                  tables and file systems on devices.
+                properties:
+                  filesystems:
+                    description: Filesystems specifies the list of file systems to
+                      setup.
+                    items:
+                      description: Filesystem defines the file systems to be created.
+                      properties:
+                        device:
+                          description: Device specifies the device name
+                          type: string
+                        extraOpts:
+                          description: ExtraOpts defined extra options to add to the
+                            command for creating the file system.
+                          items:
+                            type: string
+                          type: array
+                        filesystem:
+                          description: Filesystem specifies the file system type.
+                          type: string
+                        label:
+                          description: Label specifies the file system label to be
+                            used. If set to None, no label is used.
+                          type: string
+                        overwrite:
+                          description: |-
+                            Overwrite defines whether or not to overwrite any existing filesystem.
+                            If true, any pre-existing file system will be destroyed. Use with Caution.
+                          type: boolean
+                        partition:
+                          description: 'Partition specifies the partition to use.
+                            The valid options are: "auto|any", "auto", "any", "none",
+                            and <NUM>, where NUM is the actual partition number.'
+                          type: string
+                      required:
+                      - device
+                      - filesystem
+                      - label
+                      type: object
+                    type: array
+                  partitions:
+                    description: Partitions specifies the list of the partitions to
+                      setup.
+                    items:
+                      description: Partition defines how to create and layout a partition.
+                      properties:
+                        device:
+                          description: Device is the name of the device.
+                          type: string
+                        layout:
+                          description: |-
+                            Layout specifies the device layout.
+                            If it is true, a single partition will be created for the entire device.
+                            When layout is false, it means don't partition or ignore existing partitioning.
+                          type: boolean
+                        overwrite:
+                          description: |-
+                            Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                            Use with caution. Default is 'false'.
+                          type: boolean
+                        tableType:
+                          description: |-
+                            TableType specifies the tupe of partition table. The following are supported:
+                            'mbr': default and setups a MS-DOS partition table
+                            'gpt': setups a GPT partition table
+                          type: string
+                      required:
+                      - device
+                      - layout
+                      type: object
+                    type: array
+                type: object
+              featureGates:
+                additionalProperties:
+                  type: boolean
+                description: FeatureGates holds key-value pairs to enable or disable
+                  application features.
+                type: object
+              files:
+                description: Files specifies extra files to be passed to user_data
+                  upon creation.
+                items:
+                  description: File defines the input for generating write_files in
+                    cloud-init.
+                  properties:
+                    append:
+                      description: Append specifies whether to append Content to existing
+                        file if Path exists.
+                      type: boolean
+                    content:
+                      description: Content is the actual content of the file.
+                      type: string
+                    contentFrom:
+                      description: ContentFrom is a referenced source of content to
+                        populate the file.
+                      properties:
+                        secret:
+                          description: Secret represents a secret that should populate
+                            this file.
+                          properties:
+                            key:
+                              description: Key is the key in the secret's data map
+                                for this value.
+                              type: string
+                            name:
+                              description: Name of the secret in the KubeadmBootstrapConfig's
+                                namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    encoding:
+                      description: Encoding specifies the encoding of the file contents.
+                      enum:
+                      - base64
+                      - gzip
+                      - gzip+base64
+                      type: string
+                    owner:
+                      description: Owner specifies the ownership of the file, e.g.
+                        "root:root".
+                      type: string
+                    path:
+                      description: Path specifies the full path on disk where to store
+                        the file.
+                      type: string
+                    permissions:
+                      description: Permissions specifies the permissions to assign
+                        to the file, e.g. "0640".
+                      type: string
+                  required:
+                  - path
+                  type: object
+                type: array
+              kubelet:
+                description: Kubelet contains options for kubelet.
+                properties:
+                  config:
+                    description: Config is a KubeletConfiguration that will be merged
+                      with the defaults.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  flags:
+                    description: Flags are command-line kubelet arguments that will
+                      be appended to the defaults.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              mounts:
+                description: Mounts specifies a list of mount points to be setup.
+                items:
+                  description: MountPoints defines input for generated mounts in cloud-init.
+                  items:
+                    type: string
+                  type: array
+                type: array
+              ntp:
+                description: NTP specifies NTP configuration.
+                properties:
+                  enabled:
+                    description: Enabled specifies whether NTP should be enabled
+                    type: boolean
+                  servers:
+                    description: Servers specifies which NTP servers to use
+                    items:
+                      type: string
+                    type: array
+                type: object
+              preNodeadmCommands:
+                description: PreNodeadmCommands specifies extra commands to run before
+                  bootstrapping nodes.
+                items:
+                  type: string
+                type: array
+              users:
+                description: Users specifies extra users to add.
+                items:
+                  description: User defines the input for a generated user in cloud-init.
+                  properties:
+                    gecos:
+                      description: Gecos specifies the gecos to use for the user
+                      type: string
+                    groups:
+                      description: Groups specifies the additional groups for the
+                        user
+                      type: string
+                    homeDir:
+                      description: HomeDir specifies the home directory to use for
+                        the user
+                      type: string
+                    inactive:
+                      description: Inactive specifies whether to mark the user as
+                        inactive
+                      type: boolean
+                    lockPassword:
+                      description: LockPassword specifies if password login should
+                        be disabled
+                      type: boolean
+                    name:
+                      description: Name specifies the username
+                      type: string
+                    passwd:
+                      description: Passwd specifies a hashed password for the user
+                      type: string
+                    passwdFrom:
+                      description: PasswdFrom is a referenced source of passwd to
+                        populate the passwd.
+                      properties:
+                        secret:
+                          description: Secret represents a secret that should populate
+                            this password.
+                          properties:
+                            key:
+                              description: Key is the key in the secret's data map
+                                for this value.
+                              type: string
+                            name:
+                              description: Name of the secret in the KubeadmBootstrapConfig's
+                                namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    primaryGroup:
+                      description: PrimaryGroup specifies the primary group for the
+                        user
+                      type: string
+                    shell:
+                      description: Shell specifies the user's shell
+                      type: string
+                    sshAuthorizedKeys:
+                      description: SSHAuthorizedKeys specifies a list of ssh authorized
+                        keys for the user
+                      items:
+                        type: string
+                      type: array
+                    sudo:
+                      description: Sudo specifies a sudo role for the user
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            type: object
+          status:
+            description: NodeadmConfigStatus defines the observed state of NodeadmConfig.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the NodeadmConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores
+                  the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors.
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors.
+                type: string
+              initialization:
+                description: |-
+                  Initialization provides observations of the NodeadmConfig initialization process.
+                  NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
+                properties:
+                  dataSecretCreated:
+                    description: |-
+                      DataSecretCreated is true when the Machine's bootstrap secret is created.
+                      NOTE: This field is part of the Cluster API contract, and it is used to orchestrate initial Machine provisioning.
+                    type: boolean
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: |-
+                  Deprecated: This field will be removed with the CAPI v1beta2 transition
+                  Ready indicates the BootstrapData secret is ready to be consumed.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
+  name: nodeadmconfigtemplates.bootstrap.cluster.x-k8s.io
+spec:
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: NodeadmConfigTemplate
+    listKind: NodeadmConfigTemplateList
+    plural: nodeadmconfigtemplates
+    shortNames:
+    - nodeadmct
+    singular: nodeadmconfigtemplate
+  scope: Namespaced
+  versions:
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: NodeadmConfigTemplate is the Amazon EKS Bootstrap Configuration
+          Template API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeadmConfigTemplateSpec defines the desired state of templated
+              NodeadmConfig Amazon EKS Configuration resources.
+            properties:
+              template:
+                description: NodeadmConfigTemplateResource defines the Template structure.
+                properties:
+                  spec:
+                    description: |-
+                      Spec represents the NodeadmConfig each object created from the template will become.
+                      We are setting nullable to avoid this issue:
+                      https://github.com/kubernetes/kubernetes/issues/117447#issuecomment-2127733969
+                      where we cannot remove all fields with an SSA patch if they were previously set.
+                    nullable: true
+                    properties:
+                      containerd:
+                        description: Containerd contains options for containerd.
+                        properties:
+                          baseRuntimeSpec:
+                            description: BaseRuntimeSpec is the OCI runtime specification
+                              upon which all containers will be based.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          config:
+                            description: Config is an inline containerd configuration
+                              TOML that will be merged with the defaults.
+                            type: string
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation
+                          of partition tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to
+                                be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to
+                                    add to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system
+                                    type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label
+                                    to be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: |-
+                                    Overwrite defines whether or not to overwrite any existing filesystem.
+                                    If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition
+                                    to use. The valid options are: "auto|any", "auto",
+                                    "any", "none", and <NUM>, where NUM is the actual
+                                    partition number.'
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: |-
+                                    Layout specifies the device layout.
+                                    If it is true, a single partition will be created for the entire device.
+                                    When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: |-
+                                    Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                    Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: |-
+                                    TableType specifies the tupe of partition table. The following are supported:
+                                    'mbr': default and setups a MS-DOS partition table
+                                    'gpt': setups a GPT partition table
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates holds key-value pairs to enable
+                          or disable application features.
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            append:
+                              description: Append specifies whether to append Content
+                                to existing file if Path exists.
+                              type: boolean
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's
+                                        data map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the
+                                file contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where
+                                to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to
+                                assign to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      kubelet:
+                        description: Kubelet contains options for kubelet.
+                        properties:
+                          config:
+                            description: Config is a KubeletConfiguration that will
+                              be merged with the defaults.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          flags:
+                            description: Flags are command-line kubelet arguments
+                              that will be appended to the defaults.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be
+                          setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration.
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      preNodeadmCommands:
+                        description: PreNodeadmCommands specifies extra commands to
+                          run before bootstrapping nodes.
+                        items:
+                          type: string
+                        type: array
+                      users:
+                        description: Users specifies extra users to add.
+                        items:
+                          description: User defines the input for a generated user
+                            in cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the
+                                user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups
+                                for the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to
+                                use for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the
+                                user as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login
+                                should be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the username
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for
+                                the user
+                              type: string
+                            passwdFrom:
+                              description: PasswdFrom is a referenced source of passwd
+                                to populate the passwd.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should
+                                    populate this password.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's
+                                        data map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group
+                                for the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh
+                                authorized keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
   name: rosaclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -18891,9 +20135,19 @@ spec:
                   rule: self == oldSelf
                 - message: billingAccount must be a valid AWS account ID
                   rule: self.matches('^[0-9]{12}$')
+              channel:
+                description: |-
+                  Channel is the Y-stream OpenShift channel to use for this cluster, for example "stable-4.16" or "eus-4.16".
+                  This determines which Y-stream versions are available for upgrades.
+                  When not specified, OCM will determine the appropriate channel based on the cluster version.
+                  If Channel is set, ChannelGroup will be ignored.
+                pattern: ^(stable|eus|fast|candidate|nightly)-[0-9]+\.[0-9]+$
+                type: string
               channelGroup:
-                default: stable
-                description: OpenShift version channel group, default is stable.
+                description: |-
+                  OpenShift version channel group.
+                  When not specified, OCM will determine the appropriate channel group based on the cluster version.
+                  This field will be deprecated in a future release in favor of the Channel field.
                 enum:
                 - stable
                 - eus
@@ -19338,6 +20592,25 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
+              fips:
+                default: Disabled
+                description: |-
+                  FIPS configures FIPS-validated / Modules in Process cryptographic libraries.
+                  FIPS (Federal Information Processing Standard) 140-2 is a U.S. government standard
+                  that validates cryptographic modules used to protect sensitive information.
+
+                  When set to "Enabled", the cluster will use FIPS 140-2 validated cryptographic modules.
+                  This setting is immutable and cannot be changed after cluster creation.
+
+                  IMPORTANT: When FIPS is enabled, etcdEncryptionKMSARN must be provided.
+                  The KMS key must be tagged with 'red-hat:true'.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+                x-kubernetes-validations:
+                - message: fips is immutable
+                  rule: self == oldSelf
               identityRef:
                 description: |-
                   IdentityRef is a reference to an identity to be used when reconciling the managed control plane.
@@ -19706,7 +20979,6 @@ spec:
                   Required if RosaRoleConfigRef is not specified.
                 type: string
             required:
-            - channelGroup
             - region
             - rosaClusterName
             - version
@@ -19715,6 +20987,11 @@ spec:
           status:
             description: RosaControlPlaneStatus defines the observed state of ROSAControlPlane.
             properties:
+              availableChannels:
+                description: Available channels for the ROSA hosted control plane.
+                items:
+                  type: string
+                type: array
               availableUpgrades:
                 description: Available upgrades for the ROSA hosted control plane.
                 items:
@@ -20163,7 +21440,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -20400,7 +21677,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
     controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
@@ -20991,10 +22268,23 @@ rules:
   - bootstrap.cluster.x-k8s.io
   resources:
   - eksconfigs/status
+  - nodeadmconfigs/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - nodeadmconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - cluster.x-k8s.io
   resources:
@@ -21373,7 +22663,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
   name: capa-mutating-webhook-configuration
@@ -21756,7 +23046,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
   labels:
     cluster.x-k8s.io/provider: infrastructure-aws
   name: capa-validating-webhook-configuration


### PR DESCRIPTION
### Changes

Fix `cert-manager` annotation in CAPA kind charts by removing `hack.sh`.

The `hack.sh` script was incorrectly deleting Kustomize vars needed for
`cert-manager` CA injection. Without these vars, the annotation
 `cert-manager.io/inject-ca-from` remained as `$(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)`
  instead of being resolved to `capa-system/capa-serving-cert`.

  This fix removes `hack.sh` from the kind variant only.


### Testing

```
➜  cluster-api-installer git:(andclt-crd-fix) ✗ cd out/cluster-api-provider-aws-kind
  ../../hack/tools/kustomize-v5.3.0 build config/default 2>&1 | grep "cert-manager.io/inject-ca-from" | head -5
    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
    cert-manager.io/inject-ca-from: capa-system/capa-serving-cert
```