### PR TITLE
ARO-26782 - add scripts/aro-hcp for backplane-2.11

### DIFF
--- a/charts/cluster-api-kind/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_mce-capi-webhook-config-configuration.yaml
+++ b/charts/cluster-api-kind/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_mce-capi-webhook-config-configuration.yaml
@@ -1,0 +1,35 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/mce-capi-webhook-config
+  creationTimestamp: null
+  name: mce-capi-webhook-config-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: mce-capi-webhook-config-service
+      namespace: capi-system
+      path: /mutate
+      port: 9443
+  failurePolicy: Fail
+  name: mce-capi-webhook-config.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    - ipam.cluster.x-k8s.io
+    - runtime.cluster.x-k8s.io
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - '*'
+    scope: Namespaced
+  sideEffects: None

--- a/charts/cluster-api-kind/templates/apps_v1_deployment_capi-controller-manager.yaml
+++ b/charts/cluster-api-kind/templates/apps_v1_deployment_capi-controller-manager.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       containers:
       - args:
+        - --watch-filter=multicluster-engine
         - --leader-elect
         - --diagnostics-address=:8443
         - --insecure-diagnostics=false

--- a/charts/cluster-api-kind/templates/apps_v1_deployment_mce-capi-webhook-config.yaml
+++ b/charts/cluster-api-kind/templates/apps_v1_deployment_mce-capi-webhook-config.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mce-capi-webhook-config
+  name: mce-capi-webhook-config
+  namespace: capi-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mce-capi-webhook-config
+  template:
+    metadata:
+      labels:
+        app: mce-capi-webhook-config
+    spec:
+      containers:
+      - args:
+        - --webhook-port=9443
+        image: '{{ .Values.webhook.image.url  }}:{{ .Values.webhook.image.tag  }}'
+        imagePullPolicy: IfNotPresent
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      imagePullSecrets:
+      - name: capi-manager-pull-credentials
+      serviceAccount: mce-labeling-manager
+      volumes:
+      - name: cert
+        secret:
+          secretName: mce-capi-webhook-config-service-cert

--- a/charts/cluster-api-kind/templates/cert-manager.io_v1_certificate_mce-capi-webhook-config.yaml
+++ b/charts/cluster-api-kind/templates/cert-manager.io_v1_certificate_mce-capi-webhook-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mce-capi-webhook-config
+  namespace: capi-system
+spec:
+  dnsNames:
+  - mce-capi-webhook-config-service.capi-system.svc
+  - mce-capi-webhook-config-service.capi-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: mce-capi-webhook-config-issuer
+  secretName: mce-capi-webhook-config-service-cert

--- a/charts/cluster-api-kind/templates/cert-manager.io_v1_issuer_mce-capi-webhook-config-issuer.yaml
+++ b/charts/cluster-api-kind/templates/cert-manager.io_v1_issuer_mce-capi-webhook-config-issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: mce-capi-webhook-config-issuer
+  namespace: capi-system
+spec:
+  selfSigned: {}

--- a/charts/cluster-api-kind/templates/rbac.authorization.k8s.io_v1_clusterrole_mce-labeling-role.yaml
+++ b/charts/cluster-api-kind/templates/rbac.authorization.k8s.io_v1_clusterrole_mce-labeling-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/aggregate-to-manager: "true"
+    cluster.x-k8s.io/provider: cluster-api
+  name: mce-labeling-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get

--- a/charts/cluster-api-kind/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_mce-labeling-rolebinding.yaml
+++ b/charts/cluster-api-kind/templates/rbac.authorization.k8s.io_v1_clusterrolebinding_mce-labeling-rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: mce-labeling-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mce-labeling-role
+subjects:
+- kind: ServiceAccount
+  name: mce-labeling-manager
+  namespace: capi-system

--- a/charts/cluster-api-kind/templates/v1_secret_capi-manager-pull-credentials.yaml
+++ b/charts/cluster-api-kind/templates/v1_secret_capi-manager-pull-credentials.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: '{{ .Values.imagePullSecret }}'
+kind: Secret
+metadata:
+  name: capi-manager-pull-credentials
+  namespace: capi-system
+type: kubernetes.io/dockerconfigjson

--- a/charts/cluster-api-kind/templates/v1_service_mce-capi-webhook-config-service.yaml
+++ b/charts/cluster-api-kind/templates/v1_service_mce-capi-webhook-config-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mce-capi-webhook-config
+  name: mce-capi-webhook-config-service
+  namespace: capi-system
+spec:
+  ports:
+  - port: 9443
+    targetPort: 9443
+  selector:
+    app: mce-capi-webhook-config

--- a/charts/cluster-api-kind/templates/v1_serviceaccount_mce-labeling-manager.yaml
+++ b/charts/cluster-api-kind/templates/v1_serviceaccount_mce-labeling-manager.yaml
@@ -1,9 +1,7 @@
 apiVersion: v1
-imagePullSecrets:
-- name: capi-manager-pull-credentials
 kind: ServiceAccount
 metadata:
   labels:
     cluster.x-k8s.io/provider: cluster-api
-  name: capi-manager
+  name: mce-labeling-manager
   namespace: capi-system

--- a/charts/cluster-api-provider-azure-kind/templates/v1_secret_capz-manager-pull-credentials.yaml
+++ b/charts/cluster-api-provider-azure-kind/templates/v1_secret_capz-manager-pull-credentials.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: '{{ .Values.imagePullSecret }}'
+kind: Secret
+metadata:
+  name: capz-manager-pull-credentials
+  namespace: capz-system
+type: kubernetes.io/dockerconfigjson

--- a/charts/cluster-api-provider-azure-kind/templates/v1_serviceaccount_azureserviceoperator-default.yaml
+++ b/charts/cluster-api-provider-azure-kind/templates/v1_serviceaccount_azureserviceoperator-default.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
+imagePullSecrets:
+- name: capz-manager-pull-credentials
 kind: ServiceAccount
 metadata:
   labels:

--- a/charts/cluster-api-provider-azure-kind/templates/v1_serviceaccount_capz-manager.yaml
+++ b/charts/cluster-api-provider-azure-kind/templates/v1_serviceaccount_capz-manager.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
+imagePullSecrets:
+- name: capz-manager-pull-credentials
 kind: ServiceAccount
 metadata:
   labels:

--- a/config-kind/cluster-api-provider-azure/base/capz-pull-secret.yaml
+++ b/config-kind/cluster-api-provider-azure/base/capz-pull-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capz-manager-pull-credentials
+  namespace: capz-system
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: '{{ .Values.imagePullSecret }}'

--- a/config-kind/cluster-api-provider-azure/kustomization.yaml
+++ b/config-kind/cluster-api-provider-azure/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 ## condsidering resources under cluster-api-provider-azure/config/default directory to generate the CAPZ CRDs and CRs
 resources:
 - default/
+- base/capz-pull-secret.yaml
 
 transformers:
 - base/transformer.yaml
@@ -36,3 +37,19 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/image
         value: '{{ .Values.aso.image.url  }}:{{ .Values.aso.image.tag  }}'
+  - target:
+      kind: ServiceAccount
+      name: capz-manager
+    patch: |-
+      - op: add
+        path: /imagePullSecrets
+        value:
+        - name: capz-manager-pull-credentials
+  - target:
+      kind: ServiceAccount
+      name: azureserviceoperator-default
+    patch: |-
+      - op: add
+        path: /imagePullSecrets
+        value:
+        - name: capz-manager-pull-credentials

--- a/config-kind/cluster-api/base/mce-capi-webhook-config/capi-pull-secret.yaml
+++ b/config-kind/cluster-api/base/mce-capi-webhook-config/capi-pull-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capi-manager-pull-credentials
+  namespace: capi-system
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: '{{ .Values.imagePullSecret }}'

--- a/config-kind/cluster-api/base/mce-capi-webhook-config/cert.yaml
+++ b/config-kind/cluster-api/base/mce-capi-webhook-config/cert.yaml
@@ -1,0 +1,21 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: mce-capi-webhook-config-issuer
+  namespace: capi-system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mce-capi-webhook-config
+  namespace: capi-system
+spec:
+  dnsNames:
+  - mce-capi-webhook-config-service.capi-system.svc
+  - mce-capi-webhook-config-service.capi-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: mce-capi-webhook-config-issuer
+  secretName: mce-capi-webhook-config-service-cert

--- a/config-kind/cluster-api/base/mce-capi-webhook-config/deployment.yaml
+++ b/config-kind/cluster-api/base/mce-capi-webhook-config/deployment.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mce-capi-webhook-config
+  namespace: capi-system
+  labels:
+    app: mce-capi-webhook-config
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mce-capi-webhook-config
+  template:
+    metadata:
+      labels:
+        app: mce-capi-webhook-config
+    spec:
+      containers:
+      - args:
+          - --webhook-port=9443
+        image: quay.io/stolostron/mce-capi-webhook-config:latest
+        imagePullPolicy: Always
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          secretName: mce-capi-webhook-config-service-cert
+      serviceAccount: mce-labeling-manager
+      imagePullSecrets:
+      - name: capi-manager-pull-credentials

--- a/config-kind/cluster-api/base/mce-capi-webhook-config/kustomization.yaml
+++ b/config-kind/cluster-api/base/mce-capi-webhook-config/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- mutatingwebhook.yaml
+- rbac.yaml
+- cert.yaml
+- capi-pull-secret.yaml

--- a/config-kind/cluster-api/base/mce-capi-webhook-config/mutatingwebhook.yaml
+++ b/config-kind/cluster-api/base/mce-capi-webhook-config/mutatingwebhook.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mce-capi-webhook-config-service
+  namespace: capi-system
+  labels:
+    app: mce-capi-webhook-config
+spec:
+  ports:
+  - port: 9443
+    targetPort: 9443
+  selector:
+    app: mce-capi-webhook-config
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mce-capi-webhook-config-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/mce-capi-webhook-config
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  - v1alpha1
+  clientConfig:
+    service:
+      name: mce-capi-webhook-config-service
+      namespace: capi-system
+      path: /mutate
+      port: 9443
+  failurePolicy: Fail
+  sideEffects: None
+  name: mce-capi-webhook-config.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    - ipam.cluster.x-k8s.io
+    - runtime.cluster.x-k8s.io
+    - addons.cluster.x-k8s.io
+    resources:
+    - "*"
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    scope: "Namespaced"

--- a/config-kind/cluster-api/base/mce-capi-webhook-config/rbac.yaml
+++ b/config-kind/cluster-api/base/mce-capi-webhook-config/rbac.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: mce-labeling-manager
+  namespace: capi-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/aggregate-to-manager: "true"
+    cluster.x-k8s.io/provider: cluster-api
+  name: mce-labeling-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+  name: mce-labeling-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mce-labeling-role
+subjects:
+- kind: ServiceAccount
+  name: mce-labeling-manager
+  namespace: capi-system

--- a/config-kind/cluster-api/kustomization.yaml
+++ b/config-kind/cluster-api/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 ## condsidering resources under cluster-api/config/default directory to generate the CAPI CRDs and CRs
 resources:
 - default/
+- base/mce-capi-webhook-config/
+
 
 transformers:
 - base/transformer.yaml
@@ -25,3 +27,28 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/imagePullPolicy
         value: IfNotPresent
+      - op: add
+        path: /spec/template/spec/containers/0/args/0
+        value: '--watch-filter=multicluster-engine'
+  - target:
+      kind: ServiceAccount
+      name: capi-manager
+    patch: |-
+      - op: add
+        path: /imagePullSecrets
+        value:
+        - name: capi-manager-pull-credentials
+  - target:
+      kind: Deployment
+      name: mce-capi-webhook-config
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: '{{ .Values.webhook.image.url  }}:{{ .Values.webhook.image.tag  }}'
+      - op: replace
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: IfNotPresent
+      - op: add
+        path: /spec/template/spec/imagePullSecrets
+        value:
+        - name: capi-manager-pull-credentials

--- a/replace-params
+++ b/replace-params
@@ -1,5 +1,5 @@
 declare -A helm_add_args_a=(
-  [capi]="--set manager.image.url=quay.io/mveber/ose-cluster-api-rhel9            --set webhook.image.url=quay.io/mveber/mce-capi-webhook-config-rhel9"
-  [capz]="--set manager.image.url=quay.io/mveber/cluster-api-provider-azure-rhel9 --set manager.image.tag=dev-aso.4.0 --set aso.image.url=quay.io/mveber/azure-service-operator-rhel9     "
+  [capi]="--set manager.image.url=quay.io/acm-d/ose-cluster-api-rhel9            --set webhook.image.url=quay.io/acm-d/mce-capi-webhook-config-rhel9 --set manager.image.tag=v4.21 --set webhook.image.tag=2.11-dev"
+  [capz]="--set manager.image.url=quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-azure-mce-211 --set aso.image.url=quay.io/redhat-user-workloads/crt-redhat-acm-tenant/azure-service-operator-mce-211 --set manager.image.tag=2.11.0-latest --set aso.image.tag=2.11.0-latest"
 )
 

--- a/scripts/aro-hcp/aro-aso-ea-template.yaml
+++ b/scripts/aro-hcp/aro-aso-ea-template.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: redhatopenshift.azure.com/v1api20240610preview
+kind: HcpOpenShiftClustersExternalAuth
+metadata:
+  name: ${EA_OIDC_PROVIDER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  azureName: ${EA_OIDC_PROVIDER_NAME}
+  owner:
+    group: redhatopenshift.azure.com
+    kind: HcpOpenShiftCluster
+    name: ${CS_CLUSTER_NAME}
+  properties:
+    issuer:
+      url: "https://login.microsoftonline.com/${EA_AZURE_TENANT_ID}/v2.0"
+      audiences:
+        - "${EA_AZURE_CLIENT_ID}"
+    claim:
+      mappings:
+        username:
+          claim: "${EA_OIDC_USERNAME_CLAIM}"
+          prefixPolicy: "NoPrefix"
+        groups:
+          claim: "${EA_OIDC_GROUPS_CLAIM}"
+    clients:
+      - clientId: "${EA_AZURE_CLIENT_ID}"
+        component:
+          name: "console"
+          authClientNamespace: "openshift-console"
+        type: "Confidential"
+        extraScopes:
+          - "openid"
+          - "profile"

--- a/scripts/aro-hcp/aro-aso-template.yaml
+++ b/scripts/aro-hcp/aro-aso-template.yaml
@@ -1,0 +1,150 @@
+---
+apiVersion: redhatopenshift.azure.com/v1api20240610preview
+kind: HcpOpenShiftCluster
+metadata:
+  name: ${CS_CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  azureName: ${CS_CLUSTER_NAME}
+  location: ${REGION}
+  owner:
+    group: resources.azure.com
+    kind: ResourceGroup
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    secrets:
+     adminCredentials:
+       name: ${CS_CLUSTER_NAME}-kubeconfig
+       key: value
+  identity: 
+    type: UserAssigned
+    userAssignedIdentities:
+        - reference:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}"
+        - reference:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}"
+        - reference:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}"
+        - reference:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}"
+        - reference:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+        - reference:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+        - reference:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+        - reference:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}"
+        - reference:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}"
+        - reference:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}"
+  properties:
+    platform:
+      networkSecurityGroupReference:
+        group: network.azure.com
+        kind: NetworkSecurityGroup
+        name: ${NSG}
+      operatorsAuthentication:
+        userAssignedIdentities:
+          controlPlaneOperatorsReferences:
+            cloud-controller-manager:
+              armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}"
+            cloud-network-config:
+              armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}"
+            cluster-api-azure:
+              armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}"
+            control-plane:
+              armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}"
+            disk-csi-driver:
+              armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+            file-csi-driver:
+              armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+            image-registry:
+              armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+            ingress:
+              armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}"
+            kms:
+              armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}"
+          dataPlaneOperatorsReferences:
+           disk-csi-driver:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+           file-csi-driver:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+           image-registry:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+          serviceManagedIdentityReference:
+            armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}"
+      subnetReference:
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+        name: "${VNET}-${SUBNET}"
+      managedResourceGroup: "capz_node_${CS_CLUSTER_NAME}_${RESOURCEGROUPNAME}_rg"
+      outboundType: LoadBalancer
+    clusterImageRegistry:
+      state: Enabled
+    etcd:
+      dataEncryption:
+        keyManagementMode: CustomerManaged
+        customerManaged:
+          encryptionType: KMS
+          kms:
+            activeKey:
+              vaultName: "${KV}"
+              name: "etcd-data-kms-encryption-key"
+              version: "${KV_VERSION}"
+    network:
+      hostPrefix: 23
+      networkType: OVNKubernetes
+      machineCidr: "10.0.0.0/16"
+      podCidr: "10.128.0.0/14"
+      serviceCidr: "172.30.0.0/16"
+    version:
+      channelGroup: stable
+      id: "${OCP_VERSION}"
+    api:
+      visibility: Public
+  tags:
+    environment: production
+    owner: sre-team
+---
+apiVersion: redhatopenshift.azure.com/v1api20240610preview
+kind: HcpOpenShiftClustersNodePool
+metadata:
+  name: ${CS_CLUSTER_NAME}-mp-0
+  namespace: ${NAMESPACE}
+spec:
+  azureName: ${CS_CLUSTER_NAME}-mp-0
+  location: ${REGION}
+  owner:
+    group: redhatopenshift.azure.com
+    kind: HcpOpenShiftCluster
+    name: ${CS_CLUSTER_NAME}
+  properties:
+    # replicas: 2
+    autoRepair: true
+    autoScaling:
+      min: 2
+      max: 10
+    labels:
+      - key: region
+        value: ${REGION}
+    # taints:
+    #   - key: "example.com/special"
+    #     value: "true"
+    #     effect: "NoSchedule"
+    platform:
+      osDisk:
+        diskStorageAccountType: "Standard_LRS"
+        sizeGiB: 128
+      subnetReference:
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+        name: "${VNET}-${SUBNET}"
+      vmSize: "Standard_D4s_v3"
+    version:
+      channelGroup: stable
+      id: "${OCP_VERSION_MP}"
+  tags:
+    environment: production
+    cost-center: engineering

--- a/scripts/aro-hcp/aro-hcp-create-AZURE.sh
+++ b/scripts/aro-hcp/aro-hcp-create-AZURE.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+HOST_PORT=${HOST_PORT:-localhost:8443}
+
+# az cli
+SUBSCRIPTIONID=$(az account show --query id --output tsv)
+
+# sp.json
+RESOURCENAME=$(jq      -r .displayName       sp.json)
+TENANTID=$(jq          -r .tenant            sp.json)
+
+# infra-names.js (created by aro-prepare-infra.sh)
+CS_CLUSTER_NAME=$(jq   -r .CS_CLUSTER_NAME   infra-names.js)
+RESOURCEGROUPNAME=$(jq -r .RESOURCEGROUPNAME infra-names.js)
+VNET=$(jq              -r .VNET              infra-names.js)
+SUBNET=$(jq            -r .SUBNET            infra-names.js)
+REGION=$(jq            -r .REGION            infra-names.js)
+USER=$(jq              -r .USER              infra-names.js)
+NSG=$(jq               -r .NSG               infra-names.js)
+OCP_VERSION=$(jq       -r .OCP_VERSION       infra-names.js)
+OPERATORS_UAMIS_SUFFIX=$(jq -r .OPERATORS_UAMIS_SUFFIX infra-names.js)
+
+arm_system_data_header() {                                                                                                                                                                                                                   
+    echo "X-Ms-Arm-Resource-System-Data: {\"createdBy\": \"${USER}\", \"createdByType\": \"User\", \"createdAt\": \"$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")\"}"
+}
+
+correlation_headers() {
+    local HEADERS=( )
+    if [ -n "$(which uuidgen 2> /dev/null)" ]; then
+        HEADERS+=( "X-Ms-Correlation-Request-Id: $(uuidgen)" )
+        HEADERS+=( "X-Ms-Client-Request-Id: $(uuidgen)" )
+        HEADERS+=( "X-Ms-Return-Client-Request-Id: true" )
+    fi
+    printf '%s\n' "${HEADERS[@]}"
+}
+
+arm_x_ms_identity_url_header() {
+  # Requests directly against the frontend
+  # need to send a X-Ms-Identity-Url HTTP
+  # header, which simulates what ARM performs.
+  # By default we set a dummy value, which is
+  # enough in the environments where a real
+  # Managed Identities Data Plane does not
+  # exist like in the development or integration
+  # environments. The default can be overwritten
+  # by providing the environment variable
+  # ARM_X_MS_IDENTITY_URL when running the script.
+  : ${ARM_X_MS_IDENTITY_URL:="https://dummyhost.identity.azure.net"}
+  echo "X-Ms-Identity-Url: ${ARM_X_MS_IDENTITY_URL}"
+}
+
+test_api_available() {
+(arm_system_data_header; correlation_headers; arm_x_ms_identity_url_header) | curl -sSi -X PUT "${HOST_PORT}/subscriptions/${SUBSCRIPTIONID}/resourceGroups/some-non-existing-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters?api-version=2024-06-10-preview" \
+    --header @- > /dev/null 2>&1
+   echo $?
+}
+
+if [ "$(test_api_available)" != "0" ] ; then
+    ARO_HCP_DIR=ARO-HCP
+    if [ ! -d "$ARO_HCP_DIR" ] ; then
+        echo Clonning  ARO-HCP
+        git clone https://github.com/Azure/ARO-HCP.git "$ARO_HCP_DIR"
+    fi
+    KUBECONFIG_AKS=$(cd "$ARO_HCP_DIR"; DEPLOY_ENV=dev make infra.svc.aks.kubeconfigfile)
+    KUBECONFIG="$KUBECONFIG_AKS" oc port-forward -n aro-hcp svc/aro-hcp-frontend 8443:8443 &
+
+    echo -n Checking API in ${HOST_PORT}
+    sleep 2
+    N=10
+    while [ "$(test_api_available)" != "0" ] ; do
+        N=$(( N - 1 ))
+        if [ "$N" -le 0 ] ; then
+            echo " CAN NOT ACCESS AZURE API"
+            exit 1
+        fi
+        echo -n .
+        sleep 2
+    done
+    echo OK
+fi
+
+
+MANAGEDRGNAME="$USER-$CS_CLUSTER_NAME-managed-rg"
+NSG_ID="/subscriptions/$SUBSCRIPTIONID/resourceGroups/$RESOURCEGROUPNAME/providers/Microsoft.Network/networkSecurityGroups/$NSG"
+SUBNETRESOURCEID="/subscriptions/$SUBSCRIPTIONID/resourceGroups/$RESOURCEGROUPNAME/providers/Microsoft.Network/virtualNetworks/$VNET/subnets/$SUBNET"
+CP_CONTROL_PLANE_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-control-plane-$OPERATORS_UAMIS_SUFFIX"
+CP_CAPZ_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-cluster-api-azure-$OPERATORS_UAMIS_SUFFIX"
+CP_CCM_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-cloud-controller-manager-$OPERATORS_UAMIS_SUFFIX"
+CP_INGRESS_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-ingress-$OPERATORS_UAMIS_SUFFIX"
+CP_DISK_CSI_DRIVER_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-disk-csi-driver-$OPERATORS_UAMIS_SUFFIX"
+CP_FILE_CSI_DRIVER_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-file-csi-driver-$OPERATORS_UAMIS_SUFFIX"
+CP_IMAGE_REGISTRY_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-image-registry-$OPERATORS_UAMIS_SUFFIX"
+CP_CNC_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-cloud-network-config-$OPERATORS_UAMIS_SUFFIX"
+CP_KMS_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-kms-$OPERATORS_UAMIS_SUFFIX"
+DP_DISK_CSI_DRIVER_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-dp-disk-csi-driver-$OPERATORS_UAMIS_SUFFIX"
+DP_IMAGE_REGISTRY_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-dp-image-registry-$OPERATORS_UAMIS_SUFFIX"
+DP_FILE_CSI_DRIVER_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-dp-file-csi-driver-$OPERATORS_UAMIS_SUFFIX"
+SERVICE_MANAGED_IDENTITY_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-service-managed-identity-$OPERATORS_UAMIS_SUFFIX"
+cat <<EOF | json_pp > cluster-azure-new.json
+{
+  "properties": {
+    "location": "${REGION}",
+    "name": "${S_CLUSTER_NAME}",
+    "version": {
+      "id": "${OCP_VERSION}",
+      "channelGroup": "stable"
+    },
+    "dns": {},
+    "network": {
+      "networkType": "OVNKubernetes",
+      "podCidr": "10.128.0.0/14",
+      "serviceCidr": "172.30.0.0/16",
+      "machineCidr": "10.0.0.0/16",
+      "hostPrefix": 23
+    },
+    "console": {},
+    "api": {
+      "visibility": "public"
+    },
+    "platform": {
+      "managedResourceGroup": "$MANAGEDRGNAME",
+      "subnetId": "$SUBNETRESOURCEID",
+      "outboundType": "loadBalancer",
+      "networkSecurityGroupId": "$NSG_ID",
+      "operatorsAuthentication": {
+        "userAssignedIdentities": {
+          "controlPlaneOperators": {
+            "cluster-api-azure": "$CP_CAPZ_UAMI",
+            "control-plane": "$CP_CONTROL_PLANE_UAMI",
+            "cloud-controller-manager": "$CP_CCM_UAMI",
+            "ingress": "$CP_INGRESS_UAMI",
+            "disk-csi-driver": "$CP_DISK_CSI_DRIVER_UAMI",
+            "file-csi-driver": "$CP_FILE_CSI_DRIVER_UAMI",
+            "image-registry": "$CP_IMAGE_REGISTRY_UAMI",
+            "cloud-network-config": "$CP_CNC_UAMI",
+            "kms": "$CP_KMS_UAMI"
+          },
+          "dataPlaneOperators": {
+            "disk-csi-driver": "$DP_DISK_CSI_DRIVER_UAMI",
+            "file-csi-driver": "$DP_FILE_CSI_DRIVER_UAMI",
+            "image-registry": "$DP_IMAGE_REGISTRY_UAMI"
+          },
+          "serviceManagedIdentity": "$SERVICE_MANAGED_IDENTITY_UAMI"
+        }
+      }
+    }
+  },
+  "identity": {
+    "type": "UserAssigned",
+    "userAssignedIdentities": {
+      "$CP_CAPZ_UAMI": {},
+      "$CP_CONTROL_PLANE_UAMI": {},
+      "$CP_CCM_UAMI": {},
+      "$CP_INGRESS_UAMI": {},
+      "$CP_DISK_CSI_DRIVER_UAMI": {},
+      "$CP_FILE_CSI_DRIVER_UAMI": {},
+      "$CP_IMAGE_REGISTRY_UAMI": {},
+      "$CP_CNC_UAMI": {},
+      "$CP_KMS_UAMI": {},
+      "$SERVICE_MANAGED_IDENTITY_UAMI": {}
+    }
+  }
+}
+EOF
+
+
+echo PUT "${HOST_PORT}/subscriptions/${SUBSCRIPTIONID}/resourceGroups/${RESOURCEGROUPNAME}/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/${CS_CLUSTER_NAME}?api-version=2024-06-10-preview" 
+(arm_system_data_header; correlation_headers; arm_x_ms_identity_url_header) | curl -sSi -X PUT "${HOST_PORT}/subscriptions/${SUBSCRIPTIONID}/resourceGroups/${RESOURCEGROUPNAME}/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/${CS_CLUSTER_NAME}?api-version=2024-06-10-preview" \
+    --header @- \
+    --json @cluster-azure.json
+
+echo

--- a/scripts/aro-hcp/aro-hcp-create-AZURE.sh
+++ b/scripts/aro-hcp/aro-hcp-create-AZURE.sh
@@ -100,7 +100,7 @@ cat <<EOF | json_pp > cluster-azure-new.json
 {
   "properties": {
     "location": "${REGION}",
-    "name": "${S_CLUSTER_NAME}",
+    "name": "${CS_CLUSTER_NAME}",
     "version": {
       "id": "${OCP_VERSION}",
       "channelGroup": "stable"

--- a/scripts/aro-hcp/aro-hcp-create-AZURE.sh
+++ b/scripts/aro-hcp/aro-hcp-create-AZURE.sh
@@ -96,7 +96,7 @@ DP_DISK_CSI_DRIVER_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCE
 DP_IMAGE_REGISTRY_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-dp-image-registry-$OPERATORS_UAMIS_SUFFIX"
 DP_FILE_CSI_DRIVER_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-dp-file-csi-driver-$OPERATORS_UAMIS_SUFFIX"
 SERVICE_MANAGED_IDENTITY_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-service-managed-identity-$OPERATORS_UAMIS_SUFFIX"
-cat <<EOF | json_pp > cluster-azure-new.json
+cat <<EOF | json_pp > cluster-azure.json
 {
   "properties": {
     "location": "${REGION}",

--- a/scripts/aro-hcp/aro-hcp-create.sh
+++ b/scripts/aro-hcp/aro-hcp-create.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+
+# az cli
+SUBSCRIPTIONID=$(az account show --query id --output tsv)
+
+# ocm.token
+OCM_PARAM="--use-auth-code"
+if [ -f ocm.token ] ; then
+    OCM_PARAM="--token=$(cat ocm.token)"
+fi
+ocm login --url=http://localhost:8000 "$OCM_PARAM"
+
+if [ "$(ocm get /api/aro_hcp/v1alpha1/clusters |jq -r .kind)" != "ClusterList" ] ; then
+    ARO_HCP_DIR=/home/mveber/projekty/capi/ARO-HCP
+    KUBECONFIG=$(cd "$ARO_HCP_DIR";DEPLOY_ENV=dev make infra.svc.aks.kubeconfigfile) oc port-forward svc/clusters-service 8000:8000 -n cluster-service &
+
+    N=10
+    while [ "$(ocm get /api/aro_hcp/v1alpha1/clusters 2>/dev/null|jq -r .kind)" != "ClusterList" ] ; do
+        N=$(( N - 1 ))
+        if [ "$N" -le 0 ] ; then
+            echo " CAN NOT LOGIN"
+            exit 1
+        fi
+        echo -n .
+        sleep 2
+    done
+    echo OK
+fi
+
+# sp.json
+RESOURCENAME=$(jq      -r .displayName       sp.json)
+TENANTID=$(jq          -r .tenant            sp.json)
+
+# infra-names.js (created by aro-prepare-infra.sh)
+CS_CLUSTER_NAME=$(jq   -r .CS_CLUSTER_NAME   infra-names.js)
+RESOURCEGROUPNAME=$(jq -r .RESOURCEGROUPNAME infra-names.js)
+VNET=$(jq              -r .VNET              infra-names.js)
+SUBNET=$(jq            -r .SUBNET            infra-names.js)
+REGION=$(jq            -r .REGION            infra-names.js)
+USER=$(jq              -r .USER              infra-names.js)
+NSG=$(jq               -r .NSG               infra-names.js)
+OPERATORS_UAMIS_SUFFIX=$(jq -r .OPERATORS_UAMIS_SUFFIX infra-names.js)
+
+MANAGEDRGNAME="$USER-$CS_CLUSTER_NAME-managed-rg"
+NSG_ID="/subscriptions/$SUBSCRIPTIONID/resourceGroups/$RESOURCEGROUPNAME/providers/Microsoft.Network/networkSecurityGroups/$NSG"
+SUBNETRESOURCEID="/subscriptions/$SUBSCRIPTIONID/resourceGroups/$RESOURCEGROUPNAME/providers/Microsoft.Network/virtualNetworks/$VNET/subnets/$SUBNET"
+CP_CONTROL_PLANE_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-control-plane-$OPERATORS_UAMIS_SUFFIX"
+CP_CAPZ_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-cluster-api-azure-$OPERATORS_UAMIS_SUFFIX"
+CP_CCM_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-cloud-controller-manager-$OPERATORS_UAMIS_SUFFIX"
+CP_INGRESS_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-ingress-$OPERATORS_UAMIS_SUFFIX"
+CP_DISK_CSI_DRIVER_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-disk-csi-driver-$OPERATORS_UAMIS_SUFFIX"
+CP_FILE_CSI_DRIVER_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-file-csi-driver-$OPERATORS_UAMIS_SUFFIX"
+CP_IMAGE_REGISTRY_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-image-registry-$OPERATORS_UAMIS_SUFFIX"
+CP_CNC_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-cloud-network-config-$OPERATORS_UAMIS_SUFFIX"
+CP_KMS_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-cp-kms-$OPERATORS_UAMIS_SUFFIX"
+DP_DISK_CSI_DRIVER_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-dp-disk-csi-driver-$OPERATORS_UAMIS_SUFFIX"
+DP_IMAGE_REGISTRY_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-dp-image-registry-$OPERATORS_UAMIS_SUFFIX"
+DP_FILE_CSI_DRIVER_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-dp-file-csi-driver-$OPERATORS_UAMIS_SUFFIX"
+SERVICE_MANAGED_IDENTITY_UAMI="/subscriptions/$SUBSCRIPTIONID/resourcegroups/$RESOURCEGROUPNAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$USER-$CS_CLUSTER_NAME-service-managed-identity-$OPERATORS_UAMIS_SUFFIX"
+cat <<EOF > cluster-test.json
+{
+  "name": "$CS_CLUSTER_NAME",
+  "product": {
+    "id": "aro"
+  },
+  "ccs": {
+    "enabled": true
+  },
+  "region": {
+    "id": "$REGION"
+  },
+  "hypershift": {
+    "enabled": true
+  },
+  "multi_az": true,
+  "azure": {
+    "resource_name": "$RESOURCENAME",
+    "subscription_id": "$SUBSCRIPTIONID",
+    "resource_group_name": "$RESOURCEGROUPNAME",
+    "tenant_id": "$TENANTID",
+    "managed_resource_group_name": "$MANAGEDRGNAME",
+    "subnet_resource_id": "$SUBNETRESOURCEID",
+    "network_security_group_resource_id":"$NSG_ID",
+    "operators_authentication": {
+      "managed_identities": {
+        "managed_identities_data_plane_identity_url": "https://dummyhost.identity.azure.net",
+        "control_plane_operators_managed_identities": {
+          "control-plane": {
+            "resource_id": "$CP_CONTROL_PLANE_UAMI"
+          },
+          "cluster-api-azure": {
+            "resource_id": "$CP_CAPZ_UAMI"
+          },
+          "cloud-controller-manager": {
+            "resource_id": "$CP_CCM_UAMI"
+          },
+          "ingress": {
+            "resource_id": "$CP_INGRESS_UAMI"
+          },
+          "disk-csi-driver": {
+            "resource_id": "$CP_DISK_CSI_DRIVER_UAMI"
+          },
+          "file-csi-driver": {
+            "resource_id": "$CP_FILE_CSI_DRIVER_UAMI"
+          },
+          "image-registry": {
+            "resource_id": "$CP_IMAGE_REGISTRY_UAMI"
+          },
+          "cloud-network-config": {
+            "resource_id": "$CP_CNC_UAMI"
+          },
+          "kms": {
+            "resource_id": "$CP_KMS_UAMI"
+          }
+        },
+        "data_plane_operators_managed_identities": {
+          "disk-csi-driver": {
+            "resource_id": "$DP_DISK_CSI_DRIVER_UAMI"
+          },
+          "image-registry": {
+            "resource_id": "$DP_IMAGE_REGISTRY_UAMI"
+          },
+          "file-csi-driver": {
+            "resource_id": "$DP_FILE_CSI_DRIVER_UAMI"
+          }
+        },
+        "service_managed_identity": {
+          "resource_id": "$SERVICE_MANAGED_IDENTITY_UAMI"
+        }
+      }
+    }
+  }
+}
+EOF
+
+cat cluster-test.json | ocm post /api/aro_hcp/v1alpha1/clusters

--- a/scripts/aro-hcp/aro-hcp-create.sh
+++ b/scripts/aro-hcp/aro-hcp-create.sh
@@ -12,7 +12,11 @@ fi
 ocm login --url=http://localhost:8000 "$OCM_PARAM"
 
 if [ "$(ocm get /api/aro_hcp/v1alpha1/clusters |jq -r .kind)" != "ClusterList" ] ; then
-    ARO_HCP_DIR=/home/mveber/projekty/capi/ARO-HCP
+    ARO_HCP_DIR=${ARO_HCP_DIR:-ARO-HCP}
+    if [ ! -d "$ARO_HCP_DIR" ] ; then
+        echo "Cloning ARO-HCP"
+        git clone https://github.com/Azure/ARO-HCP.git "$ARO_HCP_DIR"
+    fi
     KUBECONFIG=$(cd "$ARO_HCP_DIR";DEPLOY_ENV=dev make infra.svc.aks.kubeconfigfile) oc port-forward svc/clusters-service 8000:8000 -n cluster-service &
 
     N=10

--- a/scripts/aro-hcp/aro-hcp-gen-template.sh
+++ b/scripts/aro-hcp/aro-hcp-gen-template.sh
@@ -1,0 +1,768 @@
+#!/bin/bash
+OUT_FILE=$(dirname $0)/aro-template-new.yaml
+
+
+cat <<EOF | cat > $OUT_FILE
+# Equivalent to:
+# az group create --name "\${RESOURCEGROUPNAME}" --location "\${REGION}"
+# This YAML creates a Resource Group named "\${RESOURCEGROUPNAME}" in the specified Azure region "\${REGION}".
+apiVersion: resources.azure.com/v1api20200601
+kind: ResourceGroup
+metadata:
+  name: \${RESOURCEGROUPNAME}
+  namespace: default
+spec:
+  location: \${REGION}
+---
+# Equivalent to:
+# az network vnet create -n "\${VNET}" -g "\${RESOURCEGROUPNAME}"
+# This YAML creates a virtual network named "\${VNET}" in the "\${RESOURCEGROUPNAME}" resource group.
+apiVersion: network.azure.com/v1api20201101
+kind: VirtualNetwork
+metadata:
+  name: \${VNET}
+  namespace: default
+spec:
+  location: \${REGION}
+  owner:
+    name: \${RESOURCEGROUPNAME}
+  addressSpace:
+    addressPrefixes:
+      - 10.100.0.0/15
+---
+# Equivalent to:
+# az network nsg create -n "\${NSG}" -g "\${RESOURCEGROUPNAME}"
+# This YAML creates a Network Security Group (NSG) named "\${NSG}" in the "\${RESOURCEGROUPNAME}" resource group.
+apiVersion: network.azure.com/v1api20201101
+kind: NetworkSecurityGroup
+metadata:
+  name: \${NSG}
+  namespace: default
+spec:
+  location: \${REGION}
+  owner:
+    name: \${RESOURCEGROUPNAME}
+---
+# Equivalent to:
+# az network vnet subnet create -n "\${SUBNET}" -g "\${RESOURCEGROUPNAME}" --vnet-name "\${VNET}" --network-security-group "\${NSG}"
+# This YAML creates a subnet named "\${SUBNET}" in the "\${VNET}" virtual network and associates it with the "\${NSG}" Network Security Group.
+apiVersion: network.azure.com/v1api20201101
+kind: VirtualNetworksSubnet
+metadata:
+  name: \${VNET}-\${SUBNET}
+  namespace: default
+spec:
+  owner:
+    name: \${VNET}
+  addressPrefix: 10.100.76.0/24
+  azureName: \${SUBNET}
+  networkSecurityGroup:
+    reference:
+      name: \${NSG}
+      group: network.azure.com
+      kind: NetworkSecurityGroup
+---
+# Equivalent to:
+# az keyvault create --name "\$KV" -g \${RESOURCEGROUPNAME} --location "\${REGION}" --enable-rbac-authorization true
+# This YAML creates a key vault named "\${KV}" in the "\${RESOURCEGROUPNAME}" resource group.
+apiVersion: keyvault.azure.com/v1api20230701
+kind: Vault
+metadata:
+  name: "\${KV}"
+  namespace: default
+spec:
+  location: "\${REGION}"
+  owner:
+    name: "\${RESOURCEGROUPNAME}"
+  properties:
+    createMode: createOrRecover
+    enableRbacAuthorization: true
+    enabledForDiskEncryption: false
+    enabledForTemplateDeployment: false
+    enableSoftDelete: true
+    tenantId: "\${AZURE_TENANT_ID}"
+    accessPolicies: [] 
+    sku:
+      family: A
+      name: standard
+EOF
+
+for IDENTITY_NAME in \
+    \${USER}-\${CS_CLUSTER_NAME}-cp-control-plane-\${OPERATORS_UAMIS_SUFFIX} \
+    \${USER}-\${CS_CLUSTER_NAME}-cp-cluster-api-azure-\${OPERATORS_UAMIS_SUFFIX} \
+    \${USER}-\${CS_CLUSTER_NAME}-cp-cloud-controller-manager-\${OPERATORS_UAMIS_SUFFIX} \
+    \${USER}-\${CS_CLUSTER_NAME}-cp-ingress-\${OPERATORS_UAMIS_SUFFIX} \
+    \${USER}-\${CS_CLUSTER_NAME}-cp-disk-csi-driver-\${OPERATORS_UAMIS_SUFFIX} \
+    \${USER}-\${CS_CLUSTER_NAME}-cp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX} \
+    \${USER}-\${CS_CLUSTER_NAME}-cp-image-registry-\${OPERATORS_UAMIS_SUFFIX} \
+    \${USER}-\${CS_CLUSTER_NAME}-cp-cloud-network-config-\${OPERATORS_UAMIS_SUFFIX} \
+    \${USER}-\${CS_CLUSTER_NAME}-cp-kms-\${OPERATORS_UAMIS_SUFFIX} \
+    \
+    \${USER}-\${CS_CLUSTER_NAME}-dp-disk-csi-driver-\${OPERATORS_UAMIS_SUFFIX} \
+    \${USER}-\${CS_CLUSTER_NAME}-dp-image-registry-\${OPERATORS_UAMIS_SUFFIX} \
+    \${USER}-\${CS_CLUSTER_NAME}-dp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX} \
+    \
+    \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX} \
+; do
+cat >> $OUT_FILE <<EOF
+---
+# Equivalent to:
+# az identity create -n "$IDENTITY_NAME" -g "\${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "$IDENTITY_NAME" in the "\${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: $IDENTITY_NAME
+  namespace: default
+spec:
+  location: \${REGION}
+  owner:
+    name: \${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-$IDENTITY_NAME
+        key: principalId
+      clientId:
+        name: identity-map-$IDENTITY_NAME
+        key: clientId
+EOF
+done
+
+cat >> $OUT_FILE <<EOF
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-cp-cluster-api-azure-\${OPERATORS_UAMIS_SUFFIX}-hcpclusterapiproviderroleid-subnet
+  namespace: default
+spec:
+  owner:
+    name: \${VNET}-\${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-cp-cluster-api-azure-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 88366f10-ed47-4cc0-9fab-c8a06148393e represents 'hcpClusterApiProviderRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-readerroleid-clusterapiazuremi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-cp-cluster-api-azure-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-cp-kms-\${OPERATORS_UAMIS_SUFFIX}-keyvaultcryptouserroleid-keyvault
+  namespace: default
+spec:
+  owner:
+    name: \${KV}
+    group: keyvault.azure.com
+    kind: Vault
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-cp-kms-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 12338af0-0e69-4776-bea7-57ae8d297424 represents 'keyVaultCryptoUserRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/12338af0-0e69-4776-bea7-57ae8d297424
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-readerroleid-kmsmi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-cp-kms-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-cp-control-plane-\${OPERATORS_UAMIS_SUFFIX}-hcpcontrolplaneoperatorroleid-vnet
+  namespace: default
+spec:
+  owner:
+    name: \${VNET}
+    group: network.azure.com
+    kind: VirtualNetwork
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-cp-control-plane-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # fc0c873f-45e9-4d0d-a7d1-585aab30c6ed represents 'hcpControlPlaneOperatorRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-cp-control-plane-\${OPERATORS_UAMIS_SUFFIX}-hcpcontrolplaneoperatorroleid-nsg
+  namespace: default
+spec:
+  owner:
+    name: \${NSG}
+    group: network.azure.com
+    kind: NetworkSecurityGroup
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-cp-control-plane-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # fc0c873f-45e9-4d0d-a7d1-585aab30c6ed represents 'hcpControlPlaneOperatorRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-readerroleid-controlplanemi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-cp-control-plane-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-cp-cloud-controller-manager-\${OPERATORS_UAMIS_SUFFIX}-cloudcontrollermanagerroleid-subnet
+  namespace: default
+spec:
+  owner:
+    name: \${VNET}-\${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-cp-cloud-controller-manager-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # a1f96423-95ce-4224-ab27-4e3dc72facd4 represents 'cloudControllerManagerRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-cp-cloud-controller-manager-\${OPERATORS_UAMIS_SUFFIX}-cloudcontrollermanagerroleid-nsg
+  namespace: default
+spec:
+  owner:
+    name: \${NSG}
+    group: network.azure.com
+    kind: NetworkSecurityGroup
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-cp-cloud-controller-manager-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # a1f96423-95ce-4224-ab27-4e3dc72facd4 represents 'cloudControllerManagerRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-readerroleid-cloudcontrollermanagermi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-cp-cloud-controller-manager-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-cp-ingress-\${OPERATORS_UAMIS_SUFFIX}-ingressoperatorroleid-subnet
+  namespace: default
+spec:
+  owner:
+    name: \${VNET}-\${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-cp-ingress-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 0336e1d3-7a87-462b-b6db-342b63f7802c represents 'ingressOperatorRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0336e1d3-7a87-462b-b6db-342b63f7802c
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-readerroleid-ingressmi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-cp-ingress-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-readerroleid-diskcsidrivermi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-cp-disk-csi-driver-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-cp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-subnet
+  namespace: default
+spec:
+  owner:
+    name: \${VNET}-\${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-cp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-cp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-nsg
+  namespace: default
+spec:
+  owner:
+    name: \${NSG}
+    group: network.azure.com
+    kind: NetworkSecurityGroup
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-cp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-readerroleid-filecsidrivermi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-cp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-readerroleid-imageregistrymi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-cp-image-registry-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-cp-cloud-network-config-\${OPERATORS_UAMIS_SUFFIX}-networkoperatorroleid-subnet
+  namespace: default
+spec:
+  owner:
+    name: \${VNET}-\${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-cp-cloud-network-config-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # be7a6435-15ae-4171-8f30-4a343eff9e8f represents 'networkOperatorRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-cp-cloud-network-config-\${OPERATORS_UAMIS_SUFFIX}-networkoperatorroleid-vnet
+  namespace: default
+spec:
+  owner:
+    name: \${VNET}
+    group: network.azure.com
+    kind: VirtualNetwork
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-cp-cloud-network-config-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # be7a6435-15ae-4171-8f30-4a343eff9e8f represents 'networkOperatorRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-readerroleid-cloudnetworkconfigmi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-cp-cloud-network-config-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpdiskcsidrivermi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-dp-disk-csi-driver-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpfilecsidrivermi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-dp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-dp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-subnet
+  namespace: default
+spec:
+  owner:
+    name: \${VNET}-\${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-dp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-dp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-nsg
+  namespace: default
+spec:
+  owner:
+    name: \${NSG}
+    group: network.azure.com
+    kind: NetworkSecurityGroup
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-dp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpimageregistrymi
+  namespace: default
+spec:
+  owner:
+    name: \${USER}-\${CS_CLUSTER_NAME}-dp-image-registry-\${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-vnet
+  namespace: default
+spec:
+  owner:
+    name: \${VNET}
+    group: network.azure.com
+    kind: VirtualNetwork
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-subnet
+  namespace: default
+spec:
+  owner:
+    name: \${VNET}-\${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: \${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-nsg
+  namespace: default
+spec:
+  owner:
+    name: \${NSG}
+    group: network.azure.com
+    kind: NetworkSecurityGroup
+  principalIdFromConfig:
+    name: identity-map-\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+    armId: /subscriptions/\${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AROControlPlane
+metadata:
+ name: \${CS_CLUSTER_NAME}-control-plane
+ namespace: default
+spec:
+ aroClusterName: \${CS_CLUSTER_NAME}
+ platform:
+   location: \${REGION}
+   resourceGroup: \${RESOURCEGROUPNAME}
+   subnet: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourceGroups/\${RESOURCEGROUPNAME}/providers/Microsoft.Network/virtualNetworks/\${VNET}/subnets/\${SUBNET}"
+   keyVault: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourceGroups/\${RESOURCEGROUPNAME}/providers/Microsoft.KeyVault/vaults/\${KV}"
+   outboundType: LoadBalancer
+   networkSecurityGroupId: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourceGroups/\${RESOURCEGROUPNAME}/providers/Microsoft.Network/networkSecurityGroups/\${NSG}"
+   managedIdentities:
+     controlPlaneOperators:
+       cloudControllerManager: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-cp-cloud-controller-manager-\${OPERATORS_UAMIS_SUFFIX}"
+       cloudNetworkConfigManagedIdentities: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-cp-cloud-network-config-\${OPERATORS_UAMIS_SUFFIX}"
+       clusterApiAzureManagedIdentities: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-cp-cluster-api-azure-\${OPERATORS_UAMIS_SUFFIX}"
+       controlPlaneOperatorsManagedIdentities: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-cp-control-plane-\${OPERATORS_UAMIS_SUFFIX}"
+       diskCsiDriverManagedIdentities: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-cp-disk-csi-driver-\${OPERATORS_UAMIS_SUFFIX}"
+       fileCsiDriverManagedIdentities: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-cp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}"
+       imageRegistryManagedIdentities: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-cp-image-registry-\${OPERATORS_UAMIS_SUFFIX}"
+       ingressManagedIdentities: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-cp-ingress-\${OPERATORS_UAMIS_SUFFIX}"
+       kmsManagedIdentities: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-cp-kms-\${OPERATORS_UAMIS_SUFFIX}"
+     dataPlaneOperators:
+       diskCsiDriverManagedIdentities: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-dp-disk-csi-driver-\${OPERATORS_UAMIS_SUFFIX}"
+       fileCsiDriverManagedIdentities: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-dp-file-csi-driver-\${OPERATORS_UAMIS_SUFFIX}"
+       imageRegistryManagedIdentities: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-dp-image-registry-\${OPERATORS_UAMIS_SUFFIX}"
+     serviceManagedIdentity: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourcegroups/\${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/\${USER}-\${CS_CLUSTER_NAME}-service-managed-identity-\${OPERATORS_UAMIS_SUFFIX}"
+ visibility: Public
+ network:
+   machineCIDR: "10.0.0.0/16"
+   podCIDR: "10.128.0.0/14"
+   serviceCIDR: "172.30.0.0/16"
+   hostPrefix: 23
+   networkType: OVNKubernetes
+ domainPrefix: \${CS_CLUSTER_NAME}
+ version: "\${OCP_VERSION}"
+ channelGroup: stable
+ versionGate: WaitForAcknowledge
+ subscriptionID: "\${AZURE_SUBSCRIPTION_ID}"
+ identityRef:
+    kind: AzureClusterIdentity
+    name: \${AZURE_CLUSTER_IDENTITY_NAME}
+    namespace: \${AZURE_CLUSTER_IDENTITY_NAMESPACE}
+ additionalTags:
+   environment: production
+   owner: sre-team
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AROMachinePool
+metadata:
+ name: \${CS_CLUSTER_NAME}-mp-0
+ namespace: default
+spec:
+  nodePoolName: w-\${REGION}-mp-0
+  version: "\${OCP_VERSION_MP}"
+  platform:
+    subnet: "/subscriptions/\${AZURE_SUBSCRIPTION_ID}/resourceGroups/\${RESOURCEGROUPNAME}/providers/Microsoft.Network/virtualNetworks/\${VNET}/subnets/\${SUBNET}"
+    vmSize: "Standard_D4s_v3"
+    diskSizeGiB: 128
+    diskStorageAccountType: "Premium_LRS"
+  labels:
+     region: \${REGION}
+  # taints:
+  #   - key: "example.com/special"
+  #     value: "true"
+  #     effect: "NoSchedule"
+  additionalTags:
+    environment: production
+    cost-center: engineering
+  autoRepair: true
+  autoscaling:
+    minReplicas: 2
+    maxReplicas: 4
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachinePool
+metadata:
+  name: \${CS_CLUSTER_NAME}-mp-0
+  namespace: default
+  labels:
+    cluster.x-k8s.io/cluster-name: \${CS_CLUSTER_NAME}
+spec:
+  replicas: 2
+  clusterName: \${CS_CLUSTER_NAME}
+  template:
+    spec:
+      bootstrap:
+        dataSecretName: \${CS_CLUSTER_NAME}-kubeconfig
+#        configRef:
+#           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+#           kind: KubeadmConfig
+#           name: \${CS_CLUSTER_NAME}-mp-0
+#           namespace: default
+      clusterName: \${CS_CLUSTER_NAME}
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: AROMachinePool
+        name: \${CS_CLUSTER_NAME}-mp-0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AROCluster
+metadata:
+ name: \${CS_CLUSTER_NAME}
+ namespace: default
+ labels:
+   cluster.x-k8s.io/cluster-name: \${CS_CLUSTER_NAME}
+spec:
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: \${CS_CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: AROControlPlane
+    name: \${CS_CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: AROCluster
+    name: \${CS_CLUSTER_NAME}
+---
+EOF

--- a/scripts/aro-hcp/aro-prepare-infra.sh
+++ b/scripts/aro-hcp/aro-prepare-infra.sh
@@ -1,0 +1,208 @@
+# export OICD_RESOURCE_GROUP=mveber-oidc-issuer
+# export USER_ASSIGNED_IDENTITY=mveber-aso-tests
+# az cli
+export AZURE_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+export AZURE_SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
+export USER=${USER:-user1}
+export CS_CLUSTER_NAME=${CS_CLUSTER_NAME:-$USER-aro}
+export NAME_PREFIX=${NAME_PREFIX:-aro-hcp}
+export RESOURCEGROUPNAME="$USER-$CS_CLUSTER_NAME-$NAME_PREFIX-resgroup"
+
+[ "$AZURE_SUBSCRIPTION_NAME" == "ARO SRE Team - INT (EA Subscription 3)"    ] && export REGION=${REGION:-uksouth}
+[ "$AZURE_SUBSCRIPTION_NAME" == "ARO HCP - STAGE testing (EA Subscription)" ] && export REGION=${REGION:-uksouth}
+export REGION=${REGION:-westus3}
+if [ -n "$OICD_RESOURCE_GROUP" -a -n "$USER_ASSIGNED_IDENTITY" ] ; then
+    export AZURE_TENANT_ID=$(az identity show --query tenantId --output=tsv --resource-group="${OICD_RESOURCE_GROUP}" --name="${USER_ASSIGNED_IDENTITY}")
+    export AZURE_CLIENT_ID=$(az identity show --query clientId --output=tsv --resource-group="${OICD_RESOURCE_GROUP}" --name="${USER_ASSIGNED_IDENTITY}")
+    export AZURE_PRINCIPAL_ID=$(az identity show --query principalId --output=tsv --resource-group="${OICD_RESOURCE_GROUP}" --name="${USER_ASSIGNED_IDENTITY}")
+    az role assignment create --assignee "${AZURE_PRINCIPAL_ID}" --role Contributor --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}"
+else
+    SP_JSON_FILE="sp-$AZURE_SUBSCRIPTION_ID.json"
+    if [ ! -f "$SP_JSON_FILE" ] ; then
+        let "randomIdentifier=$RANDOM*$RANDOM"
+        servicePrincipalName="msdocs-sp-$randomIdentifier"
+        roleName="Contributor"
+        echo "Creating SP for RBAC with name $servicePrincipalName, with role $roleName and in scopes /subscriptions/$AZURE_SUBSCRIPTION_ID"
+        az ad sp create-for-rbac --name $servicePrincipalName --role $roleName --scopes /subscriptions/$AZURE_SUBSCRIPTION_ID > "$SP_JSON_FILE"
+    fi
+    export AZURE_TENANT_ID=$(jq -r .tenant "$SP_JSON_FILE")
+    export AZURE_CLIENT_ID=$(jq -r .appId "$SP_JSON_FILE")
+    export AZURE_CLIENT_SECRET=$(jq -r .password "$SP_JSON_FILE")
+fi
+export OCP_VERSION=${OCP_VERSION:-openshift-v4.18.1}
+
+# to skip do "export SKIP_CERT_MANAGER=true" before run
+if [ -z "$SKIP_CERT_MANAGER" ] ; then
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm repo update
+helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
+fi
+
+# to skip do "export SKIP_ASO2_INSTALL=true" before run
+if [ -z "$SKIP_ASO2_INSTALL" ] ; then
+
+
+if [ -z "$USE_ASO2_HELM" ] ; then
+
+export CLUSTER_TOPOLOGY=true
+export AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY=$AZURE_CLIENT_ID # for compatibility with CAPZ v1.16 templates
+
+# Settings needed for AzureClusterIdentity used by the AzureCluster
+export AZURE_CLUSTER_IDENTITY_SECRET_NAME="cluster-identity-secret"
+export CLUSTER_IDENTITY_NAME="cluster-identity"
+export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"
+
+# we need to define list of crds to install
+export ADDITIONAL_ASO_CRDS='resources.azure.com/*;containerservice.azure.com/*;keyvault.azure.com/*;managedidentity.azure.com/*;eventhub.azure.com/*;network.azure.com/*;authorization.azure.com/*'
+
+if [ -n "${AZURE_CLIENT_SECRET}" ] ; then
+    # Create a secret to include the password of the Service Principal identity created in Azure
+    # This secret will be referenced by the AzureClusterIdentity used by the AzureCluster
+    oc create secret generic "${AZURE_CLUSTER_IDENTITY_SECRET_NAME}" --from-literal=clientSecret="${AZURE_CLIENT_SECRET}" --namespace "${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}"
+fi
+
+# Finally, initialize the management cluster
+clusterctl init --infrastructure azure
+else
+helm repo add aso2 https://raw.githubusercontent.com/Azure/azure-service-operator/main/v2/charts
+helm repo update
+helm upgrade --install --devel aso2 aso2/azure-service-operator \
+        --create-namespace --wait --timeout 2m \
+        --namespace=azureserviceoperator-system \
+        --set azureSubscriptionID=$AZURE_SUBSCRIPTION_ID \
+        --set azureTenantID=$AZURE_TENANT_ID \
+        --set azureClientID=$AZURE_CLIENT_ID \
+        --set useWorkloadIdentityAuth=true \
+        --set crdPattern='resources.azure.com/*;containerservice.azure.com/*;keyvault.azure.com/*;managedidentity.azure.com/*;eventhub.azure.com/*;network.azure.com/*;authorization.azure.com/*'
+
+if [ -n "${AZURE_CLIENT_SECRET}" ] ; then
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+ name: aso-credential
+ namespace: default
+stringData:
+ AZURE_SUBSCRIPTION_ID: "$AZURE_SUBSCRIPTION_ID"
+ AZURE_TENANT_ID: "$AZURE_TENANT_ID"
+ AZURE_CLIENT_ID: "$AZURE_CLIENT_ID"
+ AZURE_CLIENT_SECRET: "$AZURE_CLIENT_SECRET"
+EOF
+fi
+fi
+fi
+
+cat <<EOF | oc apply -f -
+# Equivalent to:
+# az group create --name "$NAME_PREFIX-resgroup" --location "$REGION"
+# This YAML creates a Resource Group named "$NAME_PREFIX-resgroup" in the specified Azure region "$REGION".
+apiVersion: resources.azure.com/v1api20200601
+kind: ResourceGroup
+metadata:
+  name: $NAME_PREFIX-resgroup
+  namespace: default
+spec:
+  location: $REGION
+---
+# Equivalent to:
+# az network vnet create -n "$NAME_PREFIX-vnet" -g "$NAME_PREFIX-resgroup"
+# This YAML creates a virtual network named "$NAME_PREFIX-vnet" in the "$NAME_PREFIX-resgroup" resource group.
+apiVersion: network.azure.com/v1api20201101
+kind: VirtualNetwork
+metadata:
+  name: $NAME_PREFIX-vnet
+  namespace: default
+spec:
+  location: $REGION
+  owner:
+    name: $NAME_PREFIX-resgroup
+  addressSpace:
+    addressPrefixes:
+      - 10.100.0.0/15
+---
+# Equivalent to:
+# az network nsg create -n "$NAME_PREFIX-nsg" -g "$NAME_PREFIX-resgroup"
+# This YAML creates a Network Security Group (NSG) named "$NAME_PREFIX-nsg" in the "${NAME_PREFIX}-resgroup" resource group.
+apiVersion: network.azure.com/v1api20201101
+kind: NetworkSecurityGroup
+metadata:
+  name: $NAME_PREFIX-nsg
+  namespace: default
+spec:
+  location: $REGION
+  owner:
+    name: $NAME_PREFIX-resgroup
+---
+# Equivalent to:
+# az network vnet subnet create -n "$NAME_PREFIX-subnet" -g "$NAME_PREFIX-resgroup" --vnet-name "$NAME_PREFIX-vnet" --network-security-group "$NAME_PREFIX-nsg"
+# This YAML creates a subnet named "$NAME_PREFIX-subnet" in the "$NAME_PREFIX-vnet" virtual network and associates it with the "$NAME_PREFIX-nsg" Network Security Group.
+apiVersion: network.azure.com/v1api20201101
+kind: VirtualNetworksSubnet
+metadata:
+  name: $NAME_PREFIX-subnet
+  namespace: default
+spec:
+  owner:
+    name: $NAME_PREFIX-vnet
+  addressPrefix: 10.100.76.0/24
+  networkSecurityGroup: 
+    reference:
+      name: $NAME_PREFIX-nsg
+      group: network.azure.com
+      kind: NetworkSecurityGroup
+EOF
+USER=${USER:-user1}
+CS_CLUSTER_NAME=${CS_CLUSTER_NAME:-cluster1}
+OPERATORS_UAMIS_SUFFIX_FILE=operators-uamis-suffix.txt
+if [ ! -f "$OPERATORS_UAMIS_SUFFIX_FILE" ] ; then
+    openssl rand -hex 3 > "$OPERATORS_UAMIS_SUFFIX_FILE"
+fi
+OPERATORS_UAMIS_SUFFIX=$(cat "$OPERATORS_UAMIS_SUFFIX_FILE")
+cat > infra-names.js <<EOF
+{
+    "REGION": "$REGION",
+    "USER": "$USER",
+    "CS_CLUSTER_NAME": "$CS_CLUSTER_NAME",
+    "NSG": "$NAME_PREFIX-nsg",
+    "RESOURCEGROUPNAME": "$RESOURCEGROUPNAME",
+    "VNET": "$NAME_PREFIX-vnet",
+    "SUBNET": "$NAME_PREFIX-subnet",
+    "OCP_VERSION": "$OCP_VERSION",
+    "OPERATORS_UAMIS_SUFFIX": "$OPERATORS_UAMIS_SUFFIX"
+}
+EOF
+> AroHcpUserAssignedIdentity.yaml
+for IDENTITY_NAME in \
+    ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX} \
+    ${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX} \
+    ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX} \
+    ${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX} \
+    ${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX} \
+    ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX} \
+    ${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX} \
+    ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX} \
+    ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX} \
+    \
+    ${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX} \
+    ${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX} \
+    ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX} \
+    \
+    ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX} \
+; do 
+cat >> AroHcpUserAssignedIdentity.yaml <<EOF
+---
+# Equivalent to:
+# az identity create -n "$IDENTITY_NAME" -g "$NAME_PREFIX-resgroup"
+# This YAML creates a managed identity named "$IDENTITY_NAME" in the "$NAME_PREFIX-resgroup" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: $IDENTITY_NAME
+  namespace: default
+spec:
+  location: $REGION
+  owner:
+    name: $NAME_PREFIX-resgroup
+EOF
+done
+oc apply -f AroHcpUserAssignedIdentity.yaml

--- a/scripts/aro-hcp/aro-prepare-infra.sh
+++ b/scripts/aro-hcp/aro-prepare-infra.sh
@@ -24,7 +24,8 @@ else
         servicePrincipalName="msdocs-sp-$randomIdentifier"
         roleName="Contributor"
         echo "Creating SP for RBAC with name $servicePrincipalName, with role $roleName and in scopes /subscriptions/$AZURE_SUBSCRIPTION_ID"
-        az ad sp create-for-rbac --name $servicePrincipalName --role $roleName --scopes /subscriptions/$AZURE_SUBSCRIPTION_ID > "$SP_JSON_FILE"
+        az ad sp create-for-rbac --name "$servicePrincipalName" --role "$roleName" --scopes "/subscriptions/$AZURE_SUBSCRIPTION_ID" > "$SP_JSON_FILE"
+        chmod 600 "$SP_JSON_FILE"
     fi
     export AZURE_TENANT_ID=$(jq -r .tenant "$SP_JSON_FILE")
     export AZURE_CLIENT_ID=$(jq -r .appId "$SP_JSON_FILE")

--- a/scripts/aro-hcp/aro-prepare-infra.sh
+++ b/scripts/aro-hcp/aro-prepare-infra.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # export OICD_RESOURCE_GROUP=mveber-oidc-issuer
 # export USER_ASSIGNED_IDENTITY=mveber-aso-tests
 # az cli

--- a/scripts/aro-hcp/aro-simple.yaml
+++ b/scripts/aro-hcp/aro-simple.yaml
@@ -1,0 +1,333 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AROControlPlane
+metadata:
+ name: ${CS_CLUSTER_NAME}
+ namespace: ${NAMESPACE}
+spec:
+ subscriptionID: "${AZURE_SUBSCRIPTION_ID}"
+ identityRef:
+    kind: AzureClusterIdentity
+    name: ${AZURE_CLUSTER_IDENTITY_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_NAMESPACE}
+ resources:
+   - apiVersion: redhatopenshift.azure.com/${ARO_HCP_VERSION}
+     kind: HcpOpenShiftCluster
+     metadata:
+       name: ${CS_CLUSTER_NAME}
+       namespace: ${NAMESPACE}
+     spec:
+       azureName: ${CS_CLUSTER_NAME}
+       location: ${REGION}
+       owner:
+         name: ${RESOURCEGROUPNAME}
+       operatorSpec:
+         secrets:
+          adminCredentials:
+            name: ${CS_CLUSTER_NAME}-kubeconfig
+            key: value
+       identity: 
+         type: UserAssigned
+         userAssignedIdentities:
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}"
+       properties:
+         platform:
+           networkSecurityGroupReference:
+             group: network.azure.com
+             kind: NetworkSecurityGroup
+             name: ${NSG}
+           vnetIntegrationSubnetReference:
+             group: network.azure.com
+             kind: VirtualNetworksSubnet
+             name: "${VNET}-${SUBNET}"
+           operatorsAuthentication:
+             userAssignedIdentities:
+               controlPlaneOperatorsReferences:
+                 cloud-controller-manager:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}"
+                 cloud-network-config:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}"
+                 cluster-api-azure:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}"
+                 control-plane:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}"
+                 disk-csi-driver:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                 file-csi-driver:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                 image-registry:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+                 ingress:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}"
+                 kms:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}"
+               dataPlaneOperatorsReferences:
+                disk-csi-driver:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                file-csi-driver:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                image-registry:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+               serviceManagedIdentityReference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}"
+           subnetReference:
+             group: network.azure.com
+             kind: VirtualNetworksSubnet
+             name: "${VNET}-${SUBNET}"
+           managedResourceGroup: "capz_node_${CS_CLUSTER_NAME}_${RESOURCEGROUPNAME}_rg"
+           outboundType: LoadBalancer
+         clusterImageRegistry:
+           state: Enabled
+         etcd:
+           dataEncryption:
+             keyManagementMode: CustomerManaged
+             customerManaged:
+               encryptionType: KMS
+               kms:
+                 activeKey:
+                   vaultName: "${KV}"
+                   name: "etcd-data-kms-encryption-key"
+                 visibility: Private
+         network:
+           hostPrefix: 23
+           networkType: OVNKubernetes
+           machineCidr: "10.0.0.0/16"
+           podCidr: "10.128.0.0/14"
+           serviceCidr: "172.30.0.0/16"
+         version:
+           channelGroup: stable
+           id: "${OCP_VERSION}"
+         api:
+           visibility: Public
+       tags:
+         environment: production
+         owner: sre-team
+         aro-hcp.experimental.cluster.single-replica: SingleReplica
+         aro-hcp.experimental.cluster.size-override: Minimal
+${EA_DISABLE}   # External Authentication Configuration
+${EA_DISABLE}   # IMPORTANT: Replace the values below with your actual OIDC provider details
+${EA_DISABLE}   - apiVersion: redhatopenshift.azure.com/${ARO_HCP_VERSION}
+${EA_DISABLE}     kind: HcpOpenShiftClustersExternalAuth
+${EA_DISABLE}     metadata:
+${EA_DISABLE}       name: ${EA_OIDC_PROVIDER_NAME}
+${EA_DISABLE}       namespace: ${NAMESPACE}
+${EA_DISABLE}     spec:
+${EA_DISABLE}       azureName: ${EA_OIDC_PROVIDER_NAME}
+${EA_DISABLE}       owner:
+${EA_DISABLE}         name: ${CS_CLUSTER_NAME}
+${EA_DISABLE}       properties:
+${EA_DISABLE}         issuer:
+${EA_DISABLE}           url: "https://login.microsoftonline.com/${EA_AZURE_TENANT_ID}/v2.0"
+${EA_DISABLE}           audiences:
+${EA_DISABLE}             - "${EA_AZURE_CLIENT_ID}"
+${EA_DISABLE}         claim:
+${EA_DISABLE}           mappings:
+${EA_DISABLE}             username:
+${EA_DISABLE}               claim: "${EA_OIDC_USERNAME_CLAIM}"
+${EA_DISABLE}               prefixPolicy: "NoPrefix"
+${EA_DISABLE}             groups:
+${EA_DISABLE}               claim: "${EA_OIDC_GROUPS_CLAIM}"
+${EA_DISABLE}         clients:
+${EA_DISABLE}           - clientId: "${EA_AZURE_CLIENT_ID}"
+${EA_DISABLE}             component:
+${EA_DISABLE}               name: "console"
+${EA_DISABLE}               authClientNamespace: "openshift-console"
+${EA_DISABLE}             type: "Confidential"
+${EA_DISABLE}             extraScopes:
+${EA_DISABLE}               - "openid"
+${EA_DISABLE}               - "profile"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AROMachinePool
+metadata:
+ name: ${CS_CLUSTER_NAME}-mp1
+ namespace: ${NAMESPACE}
+spec:
+  resources:
+    - apiVersion: redhatopenshift.azure.com/${ARO_HCP_VERSION}
+      kind: HcpOpenShiftClustersNodePool
+      metadata:
+        name: ${CS_CLUSTER_NAME}-mp1
+        namespace: ${NAMESPACE}
+      spec:
+        azureName: ${CS_CLUSTER_NAME}-mp1
+        location: ${REGION}
+        owner:
+          name: ${CS_CLUSTER_NAME}
+        properties:
+          # replicas: 2
+          autoRepair: true
+          autoScaling:
+            min: 2
+            max: 10
+          labels:
+            - key: region
+              value: ${REGION}
+          # taints:
+          #   - key: "example.com/special"
+          #     value: "true"
+          #     effect: "NoSchedule"
+          platform:
+            osDisk:
+              diskStorageAccountType: "Standard_LRS"
+              sizeGiB: 128
+            subnetReference:
+              group: network.azure.com
+              kind: VirtualNetworksSubnet
+              name: "${VNET}-${SUBNET}"
+            vmSize: "Standard_D4s_v3"
+          version:
+            channelGroup: stable
+            id: "${OCP_VERSION_MP}"
+        tags:
+          environment: production
+          cost-center: engineering
+          aro-hcp.experimental.cluster.single-replica: SingleReplica
+          aro-hcp.experimental.cluster.size-override: Minimal
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachinePool
+metadata:
+  name: ${CS_CLUSTER_NAME}-mp1
+  namespace: ${NAMESPACE}
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CS_CLUSTER_NAME}
+spec:
+  replicas: 2
+  clusterName: ${CS_CLUSTER_NAME}
+  template:
+    spec:
+      bootstrap:
+        dataSecretName: ${CS_CLUSTER_NAME}-kubeconfig
+      clusterName: ${CS_CLUSTER_NAME}
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: AROMachinePool
+        name: ${CS_CLUSTER_NAME}-mp1
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AROCluster
+metadata:
+ name: ${CS_CLUSTER_NAME}
+ namespace: ${NAMESPACE}
+ labels:
+   cluster.x-k8s.io/cluster-name: ${CS_CLUSTER_NAME}
+spec:
+  resources:
+  # Equivalent to:
+  # az group create --name "${RESOURCEGROUPNAME}" --location "${REGION}"
+  # This YAML creates a Resource Group named "${RESOURCEGROUPNAME}" in the specified Azure region "${REGION}".
+  - apiVersion: resources.azure.com/v1api20200601
+    kind: ResourceGroup
+    metadata:
+      name: ${RESOURCEGROUPNAME}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+  # Equivalent to:
+  # az network vnet create -n "${VNET}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a virtual network named "${VNET}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: network.azure.com/v1api20201101
+    kind: VirtualNetwork
+    metadata:
+      name: ${VNET}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      addressSpace:
+        addressPrefixes:
+          - 10.100.0.0/15
+  # Equivalent to:
+  # az network nsg create -n "${NSG}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a Network Security Group (NSG) named "${NSG}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: network.azure.com/v1api20201101
+    kind: NetworkSecurityGroup
+    metadata:
+      name: ${NSG}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+  # Equivalent to:
+  # az network vnet subnet create -n "${SUBNET}" -g "${RESOURCEGROUPNAME}" --vnet-name "${VNET}" --network-security-group "${NSG}"
+  # This YAML creates a subnet named "${SUBNET}" in the "${VNET}" virtual network and associates it with the "${NSG}" Network Security Group.
+  - apiVersion: network.azure.com/v1api20201101
+    kind: VirtualNetworksSubnet
+    metadata:
+      name: ${VNET}-${SUBNET}
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}
+      addressPrefix: 10.100.76.0/24
+      azureName: ${SUBNET}
+      networkSecurityGroup:
+        reference:
+          name: ${NSG}
+          group: network.azure.com
+          kind: NetworkSecurityGroup
+  # Equivalent to:
+  # az keyvault create --name "$KV" -g ${RESOURCEGROUPNAME} --location "${REGION}" --enable-rbac-authorization true
+  # This YAML creates a key vault named "${KV}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: keyvault.azure.com/v1api20230701
+    kind: Vault
+    metadata:
+      name: "${KV}"
+      namespace: ${NAMESPACE}
+    spec:
+      location: "${REGION}"
+      owner:
+        name: "${RESOURCEGROUPNAME}"
+      properties:
+        createMode: createOrRecover
+        enableRbacAuthorization: true
+        enabledForDiskEncryption: false
+        enabledForTemplateDeployment: false
+        enableSoftDelete: true
+        tenantId: "${AZURE_TENANT_ID}"
+        accessPolicies: [] 
+        sku:
+          family: A
+          name: standard
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ${CS_CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: AROControlPlane
+    name: ${CS_CLUSTER_NAME}
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: AROCluster
+    name: ${CS_CLUSTER_NAME}
+---

--- a/scripts/aro-hcp/aro-template-v1api20240610preview.yaml
+++ b/scripts/aro-hcp/aro-template-v1api20240610preview.yaml
@@ -1,0 +1,1064 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AROControlPlane
+metadata:
+ name: ${CS_CLUSTER_NAME}
+ namespace: ${NAMESPACE}
+spec:
+ subscriptionID: "${AZURE_SUBSCRIPTION_ID}"
+ identityRef:
+    kind: AzureClusterIdentity
+    name: ${AZURE_CLUSTER_IDENTITY_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_NAMESPACE}
+ resources:
+   - apiVersion: redhatopenshift.azure.com/${ARO_HCP_VERSION}
+     kind: HcpOpenShiftCluster
+     metadata:
+       name: ${CS_CLUSTER_NAME}
+       namespace: ${NAMESPACE}
+     spec:
+       azureName: ${CS_CLUSTER_NAME}
+       location: ${REGION}
+       owner:
+         name: ${RESOURCEGROUPNAME}
+       operatorSpec:
+         secrets:
+          adminCredentials:
+            name: ${CS_CLUSTER_NAME}-kubeconfig
+            key: value
+       identity: 
+         type: UserAssigned
+         userAssignedIdentities:
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}"
+       properties:
+         platform:
+           networkSecurityGroupReference:
+             group: network.azure.com
+             kind: NetworkSecurityGroup
+             name: ${NSG}
+           operatorsAuthentication:
+             userAssignedIdentities:
+               controlPlaneOperatorsReferences:
+                 cloud-controller-manager:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}"
+                 cloud-network-config:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}"
+                 cluster-api-azure:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}"
+                 control-plane:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}"
+                 disk-csi-driver:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                 file-csi-driver:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                 image-registry:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+                 ingress:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}"
+                 kms:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}"
+               dataPlaneOperatorsReferences:
+                disk-csi-driver:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                file-csi-driver:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                image-registry:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+               serviceManagedIdentityReference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}"
+           subnetReference:
+             group: network.azure.com
+             kind: VirtualNetworksSubnet
+             name: "${VNET}-${SUBNET}"
+           managedResourceGroup: "capz_node_${CS_CLUSTER_NAME}_${RESOURCEGROUPNAME}_rg"
+           outboundType: LoadBalancer
+         clusterImageRegistry:
+           state: Enabled
+         etcd:
+           dataEncryption:
+             keyManagementMode: CustomerManaged
+             customerManaged:
+               encryptionType: KMS
+               kms:
+                 activeKey:
+                   vaultName: "${KV}"
+                   name: "etcd-data-kms-encryption-key"
+         network:
+           hostPrefix: 23
+           networkType: OVNKubernetes
+           machineCidr: "10.0.0.0/16"
+           podCidr: "10.128.0.0/14"
+           serviceCidr: "172.30.0.0/16"
+         version:
+           channelGroup: stable
+           id: "${OCP_VERSION}"
+         api:
+           visibility: Public
+       tags:
+         environment: production
+         owner: sre-team
+         aro-hcp.experimental.cluster.single-replica: SingleReplica
+         aro-hcp.experimental.cluster.size-override: Minimal
+${EA_DISABLE}   # External Authentication Configuration
+${EA_DISABLE}   # IMPORTANT: Replace the values below with your actual OIDC provider details
+${EA_DISABLE}   - apiVersion: redhatopenshift.azure.com/${ARO_HCP_VERSION}
+${EA_DISABLE}     kind: HcpOpenShiftClustersExternalAuth
+${EA_DISABLE}     metadata:
+${EA_DISABLE}       name: ${EA_OIDC_PROVIDER_NAME}
+${EA_DISABLE}       namespace: ${NAMESPACE}
+${EA_DISABLE}     spec:
+${EA_DISABLE}       azureName: ${EA_OIDC_PROVIDER_NAME}
+${EA_DISABLE}       owner:
+${EA_DISABLE}         name: ${CS_CLUSTER_NAME}
+${EA_DISABLE}       properties:
+${EA_DISABLE}         issuer:
+${EA_DISABLE}           url: "https://login.microsoftonline.com/${EA_AZURE_TENANT_ID}/v2.0"
+${EA_DISABLE}           audiences:
+${EA_DISABLE}             - "${EA_AZURE_CLIENT_ID}"
+${EA_DISABLE}         claim:
+${EA_DISABLE}           mappings:
+${EA_DISABLE}             username:
+${EA_DISABLE}               claim: "${EA_OIDC_USERNAME_CLAIM}"
+${EA_DISABLE}               prefixPolicy: "NoPrefix"
+${EA_DISABLE}             groups:
+${EA_DISABLE}               claim: "${EA_OIDC_GROUPS_CLAIM}"
+${EA_DISABLE}         clients:
+${EA_DISABLE}           - clientId: "${EA_AZURE_CLIENT_ID}"
+${EA_DISABLE}             component:
+${EA_DISABLE}               name: "console"
+${EA_DISABLE}               authClientNamespace: "openshift-console"
+${EA_DISABLE}             type: "Confidential"
+${EA_DISABLE}             extraScopes:
+${EA_DISABLE}               - "openid"
+${EA_DISABLE}               - "profile"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AROMachinePool
+metadata:
+ name: ${CS_CLUSTER_NAME}-mp1
+ namespace: ${NAMESPACE}
+spec:
+  resources:
+    - apiVersion: redhatopenshift.azure.com/${ARO_HCP_VERSION}
+      kind: HcpOpenShiftClustersNodePool
+      metadata:
+        name: ${CS_CLUSTER_NAME}-mp1
+        namespace: ${NAMESPACE}
+      spec:
+        azureName: ${NAME_PREFIX}-mp1
+        location: ${REGION}
+        owner:
+          name: ${CS_CLUSTER_NAME}
+        properties:
+          # replicas: 2
+          autoRepair: true
+          autoScaling:
+            min: 2
+            max: 10
+          labels:
+            - key: region
+              value: ${REGION}
+          # taints:
+          #   - key: "example.com/special"
+          #     value: "true"
+          #     effect: "NoSchedule"
+          platform:
+            osDisk:
+              diskStorageAccountType: "Standard_LRS"
+              sizeGiB: 128
+            subnetReference:
+              group: network.azure.com
+              kind: VirtualNetworksSubnet
+              name: "${VNET}-${SUBNET}"
+            vmSize: "Standard_D4s_v3"
+          version:
+            channelGroup: stable
+            id: "${OCP_VERSION_MP}"
+        tags:
+          environment: production
+          cost-center: engineering
+          aro-hcp.experimental.cluster.single-replica: SingleReplica
+          aro-hcp.experimental.cluster.size-override: Minimal
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachinePool
+metadata:
+  name: ${CS_CLUSTER_NAME}-mp1
+  namespace: ${NAMESPACE}
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CS_CLUSTER_NAME}
+spec:
+  replicas: 2
+  clusterName: ${CS_CLUSTER_NAME}
+  template:
+    spec:
+      bootstrap:
+        dataSecretName: ${CS_CLUSTER_NAME}-kubeconfig
+      clusterName: ${CS_CLUSTER_NAME}
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: AROMachinePool
+        name: ${CS_CLUSTER_NAME}-mp1
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AROCluster
+metadata:
+ name: ${CS_CLUSTER_NAME}
+ namespace: ${NAMESPACE}
+ labels:
+   cluster.x-k8s.io/cluster-name: ${CS_CLUSTER_NAME}
+spec:
+  resources:
+  # Equivalent to:
+  # az group create --name "${RESOURCEGROUPNAME}" --location "${REGION}"
+  # This YAML creates a Resource Group named "${RESOURCEGROUPNAME}" in the specified Azure region "${REGION}".
+  - apiVersion: resources.azure.com/v1api20200601
+    kind: ResourceGroup
+    metadata:
+      name: ${RESOURCEGROUPNAME}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+  # Equivalent to:
+  # az network vnet create -n "${VNET}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a virtual network named "${VNET}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: network.azure.com/v1api20201101
+    kind: VirtualNetwork
+    metadata:
+      name: ${VNET}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      addressSpace:
+        addressPrefixes:
+          - 10.100.0.0/15
+  # Equivalent to:
+  # az network nsg create -n "${NSG}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a Network Security Group (NSG) named "${NSG}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: network.azure.com/v1api20201101
+    kind: NetworkSecurityGroup
+    metadata:
+      name: ${NSG}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+  # Equivalent to:
+  # az network vnet subnet create -n "${SUBNET}" -g "${RESOURCEGROUPNAME}" --vnet-name "${VNET}" --network-security-group "${NSG}"
+  # This YAML creates a subnet named "${SUBNET}" in the "${VNET}" virtual network and associates it with the "${NSG}" Network Security Group.
+  - apiVersion: network.azure.com/v1api20201101
+    kind: VirtualNetworksSubnet
+    metadata:
+      name: ${VNET}-${SUBNET}
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}
+      addressPrefix: 10.100.76.0/24
+      azureName: ${SUBNET}
+      networkSecurityGroup:
+        reference:
+          name: ${NSG}
+          group: network.azure.com
+          kind: NetworkSecurityGroup
+  # Equivalent to:
+  # az keyvault create --name "$KV" -g ${RESOURCEGROUPNAME} --location "${REGION}" --enable-rbac-authorization true
+  # This YAML creates a key vault named "${KV}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: keyvault.azure.com/v1api20230701
+    kind: Vault
+    metadata:
+      name: "${KV}"
+      namespace: ${NAMESPACE}
+    spec:
+      location: "${REGION}"
+      owner:
+        name: "${RESOURCEGROUPNAME}"
+      properties:
+        createMode: createOrRecover
+        enableRbacAuthorization: true
+        enabledForDiskEncryption: false
+        enabledForTemplateDeployment: false
+        enableSoftDelete: true
+        tenantId: "${AZURE_TENANT_ID}"
+        accessPolicies: [] 
+        sku:
+          family: A
+          name: standard
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}-hcpclusterapiproviderroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 88366f10-ed47-4cc0-9fab-c8a06148393e represents 'hcpClusterApiProviderRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-clusterapiazuremi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}-keyvaultcryptouserroleid-keyvault
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${KV}
+        group: keyvault.azure.com
+        kind: Vault
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 12338af0-0e69-4776-bea7-57ae8d297424 represents 'keyVaultCryptoUserRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/12338af0-0e69-4776-bea7-57ae8d297424
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-kmsmi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}-hcpcontrolplaneoperatorroleid-vnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}
+        group: network.azure.com
+        kind: VirtualNetwork
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # fc0c873f-45e9-4d0d-a7d1-585aab30c6ed represents 'hcpControlPlaneOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}-hcpcontrolplaneoperatorroleid-nsg
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${NSG}
+        group: network.azure.com
+        kind: NetworkSecurityGroup
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # fc0c873f-45e9-4d0d-a7d1-585aab30c6ed represents 'hcpControlPlaneOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-controlplanemi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}-cloudcontrollermanagerroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # a1f96423-95ce-4224-ab27-4e3dc72facd4 represents 'cloudControllerManagerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}-cloudcontrollermanagerroleid-nsg
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${NSG}
+        group: network.azure.com
+        kind: NetworkSecurityGroup
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # a1f96423-95ce-4224-ab27-4e3dc72facd4 represents 'cloudControllerManagerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-cloudcontrollermanagermi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}-ingressoperatorroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 0336e1d3-7a87-462b-b6db-342b63f7802c represents 'ingressOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0336e1d3-7a87-462b-b6db-342b63f7802c
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-ingressmi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-diskcsidrivermi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-nsg
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${NSG}
+        group: network.azure.com
+        kind: NetworkSecurityGroup
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-filecsidrivermi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-imageregistrymi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}-networkoperatorroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # be7a6435-15ae-4171-8f30-4a343eff9e8f represents 'networkOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}-networkoperatorroleid-vnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}
+        group: network.azure.com
+        kind: VirtualNetwork
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # be7a6435-15ae-4171-8f30-4a343eff9e8f represents 'networkOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-cloudnetworkconfigmi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpdiskcsidrivermi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpfilecsidrivermi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-nsg
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${NSG}
+        group: network.azure.com
+        kind: NetworkSecurityGroup
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpimageregistrymi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-vnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}
+        group: network.azure.com
+        kind: VirtualNetwork
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-nsg
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${NSG}
+        group: network.azure.com
+        kind: NetworkSecurityGroup
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ${CS_CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: AROControlPlane
+    name: ${CS_CLUSTER_NAME}
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: AROCluster
+    name: ${CS_CLUSTER_NAME}
+---

--- a/scripts/aro-hcp/aro-template.yaml
+++ b/scripts/aro-hcp/aro-template.yaml
@@ -1,0 +1,1102 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: AROControlPlane
+metadata:
+ name: ${CS_CLUSTER_NAME}
+ namespace: ${NAMESPACE}
+spec:
+ subscriptionID: "${AZURE_SUBSCRIPTION_ID}"
+ identityRef:
+    kind: AzureClusterIdentity
+    name: ${AZURE_CLUSTER_IDENTITY_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_NAMESPACE}
+ resources:
+   - apiVersion: redhatopenshift.azure.com/${ARO_HCP_VERSION}
+     kind: HcpOpenShiftCluster
+     metadata:
+       name: ${CS_CLUSTER_NAME}
+       namespace: ${NAMESPACE}
+     spec:
+       azureName: ${CS_CLUSTER_NAME}
+       location: ${REGION}
+       owner:
+         name: ${RESOURCEGROUPNAME}
+       operatorSpec:
+         secrets:
+          adminCredentials:
+            name: ${CS_CLUSTER_NAME}-kubeconfig
+            key: value
+       identity: 
+         type: UserAssigned
+         userAssignedIdentities:
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}"
+             - reference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}"
+       properties:
+         platform:
+           networkSecurityGroupReference:
+             group: network.azure.com
+             kind: NetworkSecurityGroup
+             name: ${NSG}
+           operatorsAuthentication:
+             userAssignedIdentities:
+               controlPlaneOperatorsReferences:
+                 cloud-controller-manager:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}"
+                 cloud-network-config:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}"
+                 cluster-api-azure:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}"
+                 control-plane:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}"
+                 disk-csi-driver:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                 file-csi-driver:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                 image-registry:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+                 ingress:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}"
+                 kms:
+                   armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}"
+               dataPlaneOperatorsReferences:
+                disk-csi-driver:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                file-csi-driver:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
+                image-registry:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
+               serviceManagedIdentityReference:
+                 armId: "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}"
+           subnetReference:
+             group: network.azure.com
+             kind: VirtualNetworksSubnet
+             name: "${VNET}-${SUBNET}"
+           vnetIntegrationSubnetReference:
+             group: network.azure.com
+             kind: VirtualNetworksSubnet
+             name: "${VNET}-${INTEGRATION_SUBNET}"
+           managedResourceGroup: "capz_node_${CS_CLUSTER_NAME}_${RESOURCEGROUPNAME}_rg"
+           outboundType: LoadBalancer
+         clusterImageRegistry:
+           state: Enabled
+         etcd:
+           dataEncryption:
+             keyManagementMode: CustomerManaged
+             customerManaged:
+               encryptionType: KMS
+               kms:
+                 vaultName: "${KV}"
+                 visibility: Public
+                 activeKey:
+                   name: "etcd-data-kms-encryption-key"
+         network:
+           hostPrefix: 23
+           networkType: OVNKubernetes
+           machineCidr: "10.0.0.0/16"
+           podCidr: "10.128.0.0/14"
+           serviceCidr: "172.30.0.0/16"
+         version:
+           channelGroup: stable
+           id: "${OCP_VERSION}"
+         api:
+           visibility: Public
+       tags:
+         environment: production
+         owner: sre-team
+         aro-hcp.experimental.cluster.single-replica: SingleReplica
+         aro-hcp.experimental.cluster.size-override: Minimal
+${EA_DISABLE}   # External Authentication Configuration
+${EA_DISABLE}   # IMPORTANT: Replace the values below with your actual OIDC provider details
+${EA_DISABLE}   - apiVersion: redhatopenshift.azure.com/${ARO_HCP_VERSION}
+${EA_DISABLE}     kind: HcpOpenShiftClustersExternalAuth
+${EA_DISABLE}     metadata:
+${EA_DISABLE}       name: ${EA_OIDC_PROVIDER_NAME}
+${EA_DISABLE}       namespace: ${NAMESPACE}
+${EA_DISABLE}     spec:
+${EA_DISABLE}       azureName: ${EA_OIDC_PROVIDER_NAME}
+${EA_DISABLE}       owner:
+${EA_DISABLE}         name: ${CS_CLUSTER_NAME}
+${EA_DISABLE}       properties:
+${EA_DISABLE}         issuer:
+${EA_DISABLE}           url: "https://login.microsoftonline.com/${EA_AZURE_TENANT_ID}/v2.0"
+${EA_DISABLE}           audiences:
+${EA_DISABLE}             - "${EA_AZURE_CLIENT_ID}"
+${EA_DISABLE}         claim:
+${EA_DISABLE}           mappings:
+${EA_DISABLE}             username:
+${EA_DISABLE}               claim: "${EA_OIDC_USERNAME_CLAIM}"
+${EA_DISABLE}               prefixPolicy: "NoPrefix"
+${EA_DISABLE}             groups:
+${EA_DISABLE}               claim: "${EA_OIDC_GROUPS_CLAIM}"
+${EA_DISABLE}         clients:
+${EA_DISABLE}           - clientId: "${EA_AZURE_CLIENT_ID}"
+${EA_DISABLE}             component:
+${EA_DISABLE}               name: "console"
+${EA_DISABLE}               authClientNamespace: "openshift-console"
+${EA_DISABLE}             type: "Confidential"
+${EA_DISABLE}             extraScopes:
+${EA_DISABLE}               - "openid"
+${EA_DISABLE}               - "profile"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AROMachinePool
+metadata:
+ name: ${CS_CLUSTER_NAME}-mp1
+ namespace: ${NAMESPACE}
+spec:
+  resources:
+    - apiVersion: redhatopenshift.azure.com/${ARO_HCP_VERSION}
+      kind: HcpOpenShiftClustersNodePool
+      metadata:
+        name: ${CS_CLUSTER_NAME}-mp1
+        namespace: ${NAMESPACE}
+      spec:
+        azureName: ${NAME_PREFIX}-mp1
+        location: ${REGION}
+        owner:
+          name: ${CS_CLUSTER_NAME}
+        properties:
+          # replicas: 2
+          autoRepair: true
+          autoScaling:
+            min: 2
+            max: 10
+          labels:
+            - key: region
+              value: ${REGION}
+          # taints:
+          #   - key: "example.com/special"
+          #     value: "true"
+          #     effect: "NoSchedule"
+          platform:
+            osDisk:
+              diskStorageAccountType: "Standard_LRS"
+              sizeGiB: 128
+            subnetReference:
+              group: network.azure.com
+              kind: VirtualNetworksSubnet
+              name: "${VNET}-${SUBNET}"
+            vmSize: "Standard_D4s_v3"
+          version:
+            channelGroup: stable
+            id: "${OCP_VERSION_MP}"
+        tags:
+          environment: production
+          cost-center: engineering
+          aro-hcp.experimental.cluster.single-replica: SingleReplica
+          aro-hcp.experimental.cluster.size-override: Minimal
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachinePool
+metadata:
+  name: ${CS_CLUSTER_NAME}-mp1
+  namespace: ${NAMESPACE}
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CS_CLUSTER_NAME}
+spec:
+  replicas: 2
+  clusterName: ${CS_CLUSTER_NAME}
+  template:
+    spec:
+      bootstrap:
+        dataSecretName: ${CS_CLUSTER_NAME}-kubeconfig
+      clusterName: ${CS_CLUSTER_NAME}
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: AROMachinePool
+        name: ${CS_CLUSTER_NAME}-mp1
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AROCluster
+metadata:
+ name: ${CS_CLUSTER_NAME}
+ namespace: ${NAMESPACE}
+ labels:
+   cluster.x-k8s.io/cluster-name: ${CS_CLUSTER_NAME}
+spec:
+  resources:
+  # Equivalent to:
+  # az group create --name "${RESOURCEGROUPNAME}" --location "${REGION}"
+  # This YAML creates a Resource Group named "${RESOURCEGROUPNAME}" in the specified Azure region "${REGION}".
+  - apiVersion: resources.azure.com/v1api20200601
+    kind: ResourceGroup
+    metadata:
+      name: ${RESOURCEGROUPNAME}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+  # Equivalent to:
+  # az network vnet create -n "${VNET}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a virtual network named "${VNET}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: network.azure.com/v1api20201101
+    kind: VirtualNetwork
+    metadata:
+      name: ${VNET}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      addressSpace:
+        addressPrefixes:
+          - 10.100.0.0/15
+  # Equivalent to:
+  # az network nsg create -n "${NSG}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a Network Security Group (NSG) named "${NSG}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: network.azure.com/v1api20201101
+    kind: NetworkSecurityGroup
+    metadata:
+      name: ${NSG}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+  # Equivalent to:
+  # az network vnet subnet create -n "${SUBNET}" -g "${RESOURCEGROUPNAME}" --vnet-name "${VNET}" --network-security-group "${NSG}"
+  # This YAML creates a subnet named "${SUBNET}" in the "${VNET}" virtual network and associates it with the "${NSG}" Network Security Group.
+  - apiVersion: network.azure.com/v1api20201101
+    kind: VirtualNetworksSubnet
+    metadata:
+      name: ${VNET}-${SUBNET}
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}
+      addressPrefix: 10.100.76.0/24
+      azureName: ${SUBNET}
+      networkSecurityGroup:
+        reference:
+          name: ${NSG}
+          group: network.azure.com
+          kind: NetworkSecurityGroup
+  # Equivalent to:
+  # az network vnet subnet create -n "${INTEGRATION_SUBNET}" -g "${RESOURCEGROUPNAME}" --vnet-name "${VNET}" --delegations "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+  # This YAML creates a dedicated VNet integration subnet with delegation for ARO HCP.
+  - apiVersion: network.azure.com/v1api20201101
+    kind: VirtualNetworksSubnet
+    metadata:
+      name: ${VNET}-${INTEGRATION_SUBNET}
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}
+      addressPrefix: 10.100.77.0/24
+      azureName: ${INTEGRATION_SUBNET}
+      delegations:
+        - name: Microsoft.RedHatOpenShift.hcpOpenShiftClusters
+          serviceName: Microsoft.RedHatOpenShift/hcpOpenShiftClusters
+  # Equivalent to:
+  # az keyvault create --name "$KV" -g ${RESOURCEGROUPNAME} --location "${REGION}" --enable-rbac-authorization true
+  # This YAML creates a key vault named "${KV}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: keyvault.azure.com/v1api20230701
+    kind: Vault
+    metadata:
+      name: "${KV}"
+      namespace: ${NAMESPACE}
+    spec:
+      location: "${REGION}"
+      owner:
+        name: "${RESOURCEGROUPNAME}"
+      properties:
+        createMode: createOrRecover
+        enableRbacAuthorization: true
+        enabledForDiskEncryption: false
+        enabledForTemplateDeployment: false
+        enableSoftDelete: true
+        tenantId: "${AZURE_TENANT_ID}"
+        accessPolicies: [] 
+        sku:
+          family: A
+          name: standard
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  # Equivalent to:
+  # az identity create -n "${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+  # This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+  - apiVersion: managedidentity.azure.com/v1api20230131
+    kind: UserAssignedIdentity
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+      namespace: ${NAMESPACE}
+    spec:
+      location: ${REGION}
+      owner:
+        name: ${RESOURCEGROUPNAME}
+      operatorSpec:
+        configMaps:
+          principalId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+            key: principalId
+          clientId:
+            name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+            key: clientId
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}-hcpclusterapiproviderroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 88366f10-ed47-4cc0-9fab-c8a06148393e represents 'hcpClusterApiProviderRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-clusterapiazuremi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}-keyvaultcryptouserroleid-keyvault
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${KV}
+        group: keyvault.azure.com
+        kind: Vault
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 12338af0-0e69-4776-bea7-57ae8d297424 represents 'keyVaultCryptoUserRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/12338af0-0e69-4776-bea7-57ae8d297424
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-kmsmi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}-hcpcontrolplaneoperatorroleid-vnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}
+        group: network.azure.com
+        kind: VirtualNetwork
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # fc0c873f-45e9-4d0d-a7d1-585aab30c6ed represents 'hcpControlPlaneOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}-hcpcontrolplaneoperatorroleid-nsg
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${NSG}
+        group: network.azure.com
+        kind: NetworkSecurityGroup
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # fc0c873f-45e9-4d0d-a7d1-585aab30c6ed represents 'hcpControlPlaneOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-controlplanemi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}-cloudcontrollermanagerroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # a1f96423-95ce-4224-ab27-4e3dc72facd4 represents 'cloudControllerManagerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}-cloudcontrollermanagerroleid-nsg
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${NSG}
+        group: network.azure.com
+        kind: NetworkSecurityGroup
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # a1f96423-95ce-4224-ab27-4e3dc72facd4 represents 'cloudControllerManagerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-cloudcontrollermanagermi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}-ingressoperatorroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 0336e1d3-7a87-462b-b6db-342b63f7802c represents 'ingressOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0336e1d3-7a87-462b-b6db-342b63f7802c
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-ingressmi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-diskcsidrivermi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-nsg
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${NSG}
+        group: network.azure.com
+        kind: NetworkSecurityGroup
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-filecsidrivermi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-imageregistrymi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}-networkoperatorroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # be7a6435-15ae-4171-8f30-4a343eff9e8f represents 'networkOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}-networkoperatorroleid-vnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}
+        group: network.azure.com
+        kind: VirtualNetwork
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # be7a6435-15ae-4171-8f30-4a343eff9e8f represents 'networkOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-cloudnetworkconfigmi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpdiskcsidrivermi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpfilecsidrivermi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-nsg
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${NSG}
+        group: network.azure.com
+        kind: NetworkSecurityGroup
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpimageregistrymi
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+        group: managedidentity.azure.com
+        kind: UserAssignedIdentity
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-vnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}
+        group: network.azure.com
+        kind: VirtualNetwork
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-subnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-intsubnet
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${VNET}-${INTEGRATION_SUBNET}
+        group: network.azure.com
+        kind: VirtualNetworksSubnet
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+  - apiVersion: authorization.azure.com/v1api20220401
+    kind: RoleAssignment
+    metadata:
+      name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-nsg
+      namespace: ${NAMESPACE}
+    spec:
+      owner:
+        name: ${NSG}
+        group: network.azure.com
+        kind: NetworkSecurityGroup
+      principalIdFromConfig:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      principalType: ServicePrincipal
+      roleDefinitionReference:
+        # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ${CS_CLUSTER_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: AROControlPlane
+    name: ${CS_CLUSTER_NAME}
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: AROCluster
+    name: ${CS_CLUSTER_NAME}
+---

--- a/scripts/aro-hcp/credentials-sp-template.yaml
+++ b/scripts/aro-hcp/credentials-sp-template.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  name: ${AZURE_CLUSTER_IDENTITY_NAME}
+  namespace: ${AZURE_CLUSTER_IDENTITY_NAMESPACE}
+spec:
+  allowedNamespaces: {}
+  tenantID: "${AZURE_TENANT_ID}"
+  clientID: "${AZURE_CLIENT_ID}"
+  clientSecret:
+    name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
+    namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
+  type: "ServicePrincipal"
+---
+apiVersion: v1
+data:
+  clientSecret: ${AZURE_CLUSTER_IDENTITY_SECRET_BASE64}
+kind: Secret
+metadata:
+  name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
+  namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+ name: aso-credential
+ namespace: ${NAMESPACE}
+stringData:
+ AZURE_SUBSCRIPTION_ID: "${AZURE_SUBSCRIPTION_ID}"
+ AZURE_TENANT_ID: "${AZURE_TENANT_ID}"
+ AZURE_CLIENT_ID: "${AZURE_CLIENT_ID}"
+ AZURE_CLIENT_SECRET: "${AZURE_CLIENT_SECRET}"

--- a/scripts/aro-hcp/credentials-wi-template.yaml
+++ b/scripts/aro-hcp/credentials-wi-template.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  name: ${AZURE_CLUSTER_IDENTITY_NAME}
+  namespace: ${AZURE_CLUSTER_IDENTITY_NAMESPACE}
+spec:
+  allowedNamespaces: {}
+  tenantID: "${AZURE_TENANT_ID}"
+  clientID: "${AZURE_CLIENT_ID}"
+  type: WorkloadIdentity
+---
+apiVersion: v1
+kind: Secret
+metadata:
+ name: aso-credential
+ namespace: ${NAMESPACE}
+stringData:
+ AZURE_SUBSCRIPTION_ID: "${AZURE_SUBSCRIPTION_ID}"
+ AZURE_TENANT_ID: "${AZURE_ASO_TENANT_ID}"
+ AZURE_CLIENT_ID: "${AZURE_ASO_CLIENT_ID}"

--- a/scripts/aro-hcp/ea-post-deploy-update.sh
+++ b/scripts/aro-hcp/ea-post-deploy-update.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+export ARO_YAML_FILE="$1"
+if [ -z "$ARO_YAML_FILE" ] ; then
+   echo usage: $0 "<dir/aro.yaml>"
+   exit 1
+fi
+if [ ! -f "$ARO_YAML_FILE" ] ; then
+   echo "file: $ARO_YAML_FILE doesn't exists"
+   exit 1
+fi
+
+if [ "$USE_KIND" = true ] ; then
+    KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-aso2}
+    KUBE_CONTEXT="--context=kind-$KIND_CLUSTER_NAME"
+else
+    OCP_CONTEXT=${OCP_CONTEXT:-crc-admin}
+    KUBE_CONTEXT="--context=$OCP_CONTEXT"
+fi
+
+export CLUSTER_NAME=$(yq 'select(.kind == "AROControlPlane") | .spec.resources[] | select(.kind == "HcpOpenShiftCluster").spec.azureName' < "$ARO_YAML_FILE" )
+export ARO_CP_NAME=$(yq 'select(.kind == "AROControlPlane").metadata.name' < "$ARO_YAML_FILE" )
+export CLUSTER_NAMESPACE=$(yq 'select(.kind == "AROControlPlane").metadata.namespace' < "$ARO_YAML_FILE" )
+export EA_AZURE_TENANT_ID=$(yq 'select(.kind == "AROControlPlane") | .spec.resources[] | select(.kind == "HcpOpenShiftClustersExternalAuth").spec.properties.issuer.url' < "$ARO_YAML_FILE"|sed -e 's;/v2.\0$;;' -e 's;.*/;;')
+export EA_AZURE_CLIENT_ID=$(yq 'select(.kind == "AROControlPlane") | .spec.resources[] | select(.kind == "HcpOpenShiftClustersExternalAuth").spec.properties.issuer.audiences[0]' < "$ARO_YAML_FILE")
+export GROUP_NAME="aro-hcp-engineering-App Developer"
+
+export CONSOLE_URL=$(oc $KUBE_CONTEXT get -n "$CLUSTER_NAMESPACE" arocp "$ARO_CP_NAME" -o json|jq -r '.status.consoleURL')
+
+export CLUSTER_DOMAIN=${CONSOLE_URL##"https://console-openshift-console.apps."}
+
+echo "K8s-Namespace: $CLUSTER_NAMESPACE"
+echo " Cluster name: $CLUSTER_NAME"
+echo "  Console URL: $CONSOLE_URL"
+echo "       Domain: $CLUSTER_DOMAIN"
+echo "EA: ClientID:  $EA_AZURE_CLIENT_ID"
+echo "EA: TennantID: $EA_AZURE_TENANT_ID"
+if [ -z "$CLUSTER_NAME" ] ; then
+   echo no CLUSTER_NAME
+   exit 1
+fi
+if [ -z "$CLUSTER_NAMESPACE" ] ; then
+   echo no CLUSTER_NAMESPACE
+   exit 1
+fi
+if [ -z "$CONSOLE_URL" -o "$CONSOLE_URL" = "null" ] ; then
+   echo no CONSOLE_URL
+   exit 1
+fi
+if [ -z "$EA_AZURE_CLIENT_ID" ] ; then
+   echo no EA_AZURE_CLIENT_ID
+   exit 1
+fi
+if [ -z "$EA_AZURE_TENANT_ID" ] ; then
+   echo no EA_AZURE_TENANT_ID
+   exit 1
+fi
+
+az ad app update --id "$EA_AZURE_CLIENT_ID" \
+    --web-redirect-uris \
+      "https://oauth-openshift.apps.$CLUSTER_DOMAIN/oauth2callback/AAD" \
+      "$CONSOLE_URL/auth/callback"
+
+az ad app update --id "$EA_AZURE_CLIENT_ID" \
+    --enable-id-token-issuance true
+
+az ad app update --id "$EA_AZURE_CLIENT_ID" \
+    --optional-claims '{"idToken":[{"name":"groups","essential":false}]}'
+
+# Enable security group claims in the token
+az ad app update --id "$EA_AZURE_CLIENT_ID" --set groupMembershipClaims=SecurityGroup
+
+# Add Microsoft Graph User.Read permission for group claims
+# Microsoft Graph App ID: 00000003-0000-0000-c000-000000000000
+# User.Read permission ID: e1fe6dd8-ba31-4d61-89e7-88639da4683d
+az ad app permission add --id "$EA_AZURE_CLIENT_ID" \
+    --api 00000003-0000-0000-c000-000000000000 \
+    --api-permissions e1fe6dd8-ba31-4d61-89e7-88639da4683d=Scope 2>/dev/null || true
+
+APP_SECRET_FILE="ea-secret-$EA_AZURE_CLIENT_ID.json"
+if [ ! -f "$APP_SECRET_FILE" ] ; then
+    az ad app credential reset --id $EA_AZURE_CLIENT_ID --append > "$APP_SECRET_FILE"
+fi
+export AZURE_CLIENT_SECRET=$(jq -r .password "$APP_SECRET_FILE")
+if [ -z "$AZURE_CLIENT_SECRET" ] ; then
+   echo no AZURE_CLIENT_SECRET in $APP_SECRET_FILE
+   exit 1
+fi
+
+# Create the external auth console secret on the management cluster
+# This secret is required for external auth synchronization
+[ -n "$DELETE_SECRETS" ] && oc $KUBE_CONTEXT delete secret -n "$CLUSTER_NAMESPACE" "${CLUSTER_NAME}-ea-console-openshift-console"
+oc $KUBE_CONTEXT create secret generic "${CLUSTER_NAME}-ea-console-openshift-console" \
+    -n "$CLUSTER_NAMESPACE" \
+    --from-literal=clientSecret="$AZURE_CLIENT_SECRET"
+
+export KC="${CLUSTER_NAME}.kubeconfig"
+oc $KUBE_CONTEXT get secret "${CLUSTER_NAME}-kubeconfig" -n "$CLUSTER_NAMESPACE" -o jsonpath='{.data.value}' | base64 -d > "$KC"
+
+# Create the entra-console-openshift-console secret required by the console operator
+# This secret contains the OIDC client configuration
+[ -n "$DELETE_SECRETS" ] && oc --kubeconfig="$KC" delete secret -n openshift-console console-oauth-config
+oc --kubeconfig="$KC" create secret generic entra-console-openshift-console \
+    -n openshift-config \
+    --from-literal=clientID="$EA_AZURE_CLIENT_ID" \
+    --from-literal=clientSecret="$AZURE_CLIENT_SECRET" \
+    --from-literal=issuer="https://login.microsoftonline.com/$EA_AZURE_TENANT_ID/v2.0" \
+    --from-literal=extraScopes="openid,profile"
+
+export USER_OBJECT_ID=$(az ad signed-in-user show --query id -o tsv)
+
+oc --kubeconfig="$KC" create clusterrolebinding aad-admin \
+    --clusterrole=cluster-admin \
+    --user="${USER_OBJECT_ID}"
+
+export GROUP_OBJECT_ID=$(az ad group show --group "$GROUP_NAME" --query id -o tsv)
+
+oc --kubeconfig="$KC" create clusterrolebinding aad-admins-group \
+    --clusterrole=cluster-admin \
+    --group="${GROUP_OBJECT_ID}"
+

--- a/scripts/aro-hcp/ea-post-deploy-update.sh
+++ b/scripts/aro-hcp/ea-post-deploy-update.sh
@@ -96,6 +96,7 @@ oc $KUBE_CONTEXT create secret generic "${CLUSTER_NAME}-ea-console-openshift-con
 
 export KC="${CLUSTER_NAME}.kubeconfig"
 oc $KUBE_CONTEXT get secret "${CLUSTER_NAME}-kubeconfig" -n "$CLUSTER_NAMESPACE" -o jsonpath='{.data.value}' | base64 -d > "$KC"
+chmod 600 "$KC"
 
 # Create the entra-console-openshift-console secret required by the console operator
 # This secret contains the OIDC client configuration

--- a/scripts/aro-hcp/ea-post-deploy-update.sh
+++ b/scripts/aro-hcp/ea-post-deploy-update.sh
@@ -78,7 +78,8 @@ az ad app permission add --id "$EA_AZURE_CLIENT_ID" \
 
 APP_SECRET_FILE="ea-secret-$EA_AZURE_CLIENT_ID.json"
 if [ ! -f "$APP_SECRET_FILE" ] ; then
-    az ad app credential reset --id $EA_AZURE_CLIENT_ID --append > "$APP_SECRET_FILE"
+    az ad app credential reset --id "$EA_AZURE_CLIENT_ID" --append > "$APP_SECRET_FILE"
+    chmod 600 "$APP_SECRET_FILE"
 fi
 export AZURE_CLIENT_SECRET=$(jq -r .password "$APP_SECRET_FILE")
 if [ -z "$AZURE_CLIENT_SECRET" ] ; then

--- a/scripts/aro-hcp/gen.sh
+++ b/scripts/aro-hcp/gen.sh
@@ -96,6 +96,7 @@ if [ "$USE_CI" != "true" ] ; then
             roleName="Custom-Owner (Block Billing and Subscription deletion)"
             echo "Creating SP for RBAC with name $servicePrincipalName, with role $roleName and in scopes /subscriptions/$AZURE_SUBSCRIPTION_ID"
             az ad sp create-for-rbac --name "$servicePrincipalName" --role "$roleName" --scopes "/subscriptions/$AZURE_SUBSCRIPTION_ID" > "$SP_JSON_FILE"
+            chmod 600 "$SP_JSON_FILE"
         fi
         if [ -n "${ASSIGN_ROLE_SP}" ] ; then
             roleName="Custom-Owner (Block Billing and Subscription deletion)"

--- a/scripts/aro-hcp/gen.sh
+++ b/scripts/aro-hcp/gen.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+if [ -n "$1" ] ; then
+    GEN_OUTPUT="$1"; shift
+else
+    echo "usage: $0 <output-dir>"
+    exit 1
+fi
+set -e
+missing=""
+for var in REGION DEPLOYMENT_ENV AZURE_SUBSCRIPTION_ID AZURE_TENANT_ID AZURE_CLIENT_ID AZURE_CLIENT_SECRET; do
+    [ -z "${!var}" ] && missing="${missing} ${var}"
+done
+if [ -n "$missing" ]; then
+    echo "⚠  NON CI mode - required variables: ${missing}"
+else
+    echo "✓ USING CI mode"
+    export USE_CI=true
+fi
+
+export ENV=${ENV:-${DEPLOYMENT_ENV}}
+export ENV=${ENV:-stage}
+export CREATE_CREDENTIALS=true
+export NAMESPACE=${NAMESPACE:-default}
+#export ARO_HCP_VERSION=${ARO_HCP_VERSION:-v1api20251223preview}
+export ARO_HCP_VERSION=${ARO_HCP_VERSION:-v1api20240610preview}
+
+
+if [ "$USE_CI" != "true" ] ; then
+    if [ "$KIND_CLUSTER_NAME" == "capz-mveber-int" ] ; then
+        export OICD_RESOURCE_GROUP=mveber-oidc-issuer
+        export USER_ASSIGNED_IDENTITY_ASO=mveber-aso-tests
+        export USER_ASSIGNED_IDENTITY_ARO=mveber-aro-tests
+        export ENV=int
+    fi
+    
+    
+    if [ "$ENV" == devel ] ; then
+        export AZURE_SUBSCRIPTION_NAME=${AZURE_SUBSCRIPTION_NAME:-"ARO Hosted Control Planes (EA Subscription 1)"}
+        export REGION=${REGION:-uksouth}
+    fi
+
+    if [ "$ENV" == int ] ; then
+        export AZURE_SUBSCRIPTION_NAME=${AZURE_SUBSCRIPTION_NAME:-"ARO SRE Team - INT (EA Subscription 3)"}
+        export REGION=${REGION:-uksouth}
+    fi
+    
+    if [ "$ENV" == stage ] ; then
+        export AZURE_SUBSCRIPTION_NAME=${AZURE_SUBSCRIPTION_NAME:-"ARO HCP - Misc Testing (EA Subscription)"}
+        export REGION=${REGION:-uksouth}
+    fi
+
+    if [ "$ENV" == prod ] ; then
+        export AZURE_SUBSCRIPTION_NAME=${AZURE_SUBSCRIPTION_NAME:-"ARO HCP E2E Hosted Clusters (EA Subscription)"}
+        export REGION=${REGION:-switzerlandnorth}
+    fi
+    
+    export AZURE_SUBSCRIPTION_ID=$(az account show --query id --output tsv     --subscription "$AZURE_SUBSCRIPTION_NAME")
+    if [ -z "$AZURE_SUBSCRIPTION_ID" ]; then
+        echo "No such subscription: AZURE_SUBSCRIPTION_NAME=$AZURE_SUBSCRIPTION_NAME"
+        exit 1
+    fi
+    export AZURE_SUBSCRIPTION_NAME=$(az account show --query name --output tsv --subscription "$AZURE_SUBSCRIPTION_NAME")
+    
+    echo "AZURE_SUBSCRIPTION_NAME=$AZURE_SUBSCRIPTION_NAME <$AZURE_SUBSCRIPTION_ID>"
+fi
+
+export USER=${USER:-user1}
+export CS_CLUSTER_NAME=${WORKLOAD_CLUSTER_NAME:-"$CS_CLUSTER_NAME"}
+export CS_CLUSTER_NAME=${CS_CLUSTER_NAME:-$USER-$ENV}
+export NAME_PREFIX=${NAME_PREFIX:-$CS_CLUSTER_NAME}
+export RESOURCEGROUPNAME=${RESOURCEGROUPNAME:-"$CS_CLUSTER_NAME-resgroup"}
+export OCP_VERSION=${OCP_VERSION:-4.20}
+export OCP_VERSION_MP=${OCP_VERSION_MP:-$OCP_VERSION.17}
+export REGION=${REGION:-westus3}
+export NODEPOOL_PREFIX="w-${REGION:0:7}"
+export NAME_PREFIX="${NAME_PREFIX:0:14}"
+
+
+
+if [ "$USE_CI" != "true" ] ; then
+    if [ -n "$OICD_RESOURCE_GROUP" ] ; then
+        export AZURE_ASO_TENANT_ID=$(az identity show --query tenantId --output=tsv --resource-group="${OICD_RESOURCE_GROUP}" --name="${USER_ASSIGNED_IDENTITY_ASO}" --subscription "$AZURE_SUBSCRIPTION_NAME")
+        export AZURE_ASO_CLIENT_ID=$(az identity show --query clientId --output=tsv --resource-group="${OICD_RESOURCE_GROUP}" --name="${USER_ASSIGNED_IDENTITY_ASO}" --subscription "$AZURE_SUBSCRIPTION_NAME")
+        export AZURE_ASO_PRINCIPAL_ID=$(az identity show --query principalId --output=tsv --resource-group="${OICD_RESOURCE_GROUP}" --name="${USER_ASSIGNED_IDENTITY_ASO}" --subscription "$AZURE_SUBSCRIPTION_NAME")
+        # az role assignment create --assignee  "${AZURE_ASO_PRINCIPAL_ID}" --role Contributor --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}"
+        export AZURE_TENANT_ID=$(az identity show --query tenantId --output=tsv --resource-group="${OICD_RESOURCE_GROUP}" --name="${USER_ASSIGNED_IDENTITY_ARO}" --subscription "$AZURE_SUBSCRIPTION_NAME")
+        export AZURE_CLIENT_ID=$(az identity show --query clientId --output=tsv --resource-group="${OICD_RESOURCE_GROUP}" --name="${USER_ASSIGNED_IDENTITY_ARO}" --subscription "$AZURE_SUBSCRIPTION_NAME")
+        export AZURE_PRINCIPAL_ID=$(az identity show --query principalId --output=tsv --resource-group="${OICD_RESOURCE_GROUP}" --name="${USER_ASSIGNED_IDENTITY_ARO}" --subscription "$AZURE_SUBSCRIPTION_NAME")
+        # az role assignment create --assignee  "${AZURE_PRINCIPAL_ID}" --role Contributor --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}"
+    else
+        SP_JSON_FILE="sp-$AZURE_SUBSCRIPTION_ID.json"
+        if [ ! -s "$SP_JSON_FILE" ] ; then
+            let "randomIdentifier=$RANDOM*$RANDOM"
+            servicePrincipalName="$USER-sp-$randomIdentifier"
+            #roleName="Contributor"
+            roleName="Custom-Owner (Block Billing and Subscription deletion)"
+            echo "Creating SP for RBAC with name $servicePrincipalName, with role $roleName and in scopes /subscriptions/$AZURE_SUBSCRIPTION_ID"
+            az ad sp create-for-rbac --name "$servicePrincipalName" --role "$roleName" --scopes "/subscriptions/$AZURE_SUBSCRIPTION_ID" > "$SP_JSON_FILE"
+        fi
+        if [ -n "${ASSIGN_ROLE_SP}" ] ; then
+            roleName="Custom-Owner (Block Billing and Subscription deletion)"
+            export ASSIGN_ROLE_SP_NAME=$(jq -r .displayName "$SP_JSON_FILE")
+            ASSIGN_ROLE_SP_ID=$(az ad sp list --output=json  --display-name "$ASSIGN_ROLE_SP_NAME" |jq -r '.[0].id')
+            echo "assign ASSIGN_ROLE_SP_NAME=$ASSIGN_ROLE_SP_NAME to scope /subscriptions/$AZURE_SUBSCRIPTION_ID"
+            az role assignment create --assignee  "${ASSIGN_ROLE_SP_ID}" --role "$roleName" --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}"
+        fi
+        export AZURE_TENANT_ID=$(jq -r .tenant "$SP_JSON_FILE")
+        export AZURE_CLIENT_ID=$(jq -r .appId "$SP_JSON_FILE")
+        export AZURE_CLIENT_SECRET=$(jq -r .password "$SP_JSON_FILE")
+    fi
+fi
+
+
+if [ -z "$OPERATORS_UAMIS_SUFFIX" ] ; then
+    OPERATORS_UAMIS_SUFFIX_FILE="${OPERATORS_UAMIS_SUFFIX_FILE:-operators-uamis-suffix.txt}"
+    if [ ! -s "$OPERATORS_UAMIS_SUFFIX_FILE" ] ; then
+        openssl rand -hex 3 > "$OPERATORS_UAMIS_SUFFIX_FILE"
+    fi
+    export OPERATORS_UAMIS_SUFFIX=$(cat "$OPERATORS_UAMIS_SUFFIX_FILE")
+fi
+
+export VNET="$NAME_PREFIX-vnet-$OPERATORS_UAMIS_SUFFIX"
+export SUBNET="$NAME_PREFIX-subnet-$OPERATORS_UAMIS_SUFFIX"
+export INTEGRATION_SUBNET="$NAME_PREFIX-integration-subnet-$OPERATORS_UAMIS_SUFFIX"
+export NSG="$NAME_PREFIX-nsg-$OPERATORS_UAMIS_SUFFIX"
+export KV="$NAME_PREFIX-kv-$OPERATORS_UAMIS_SUFFIX"
+export KV_VERSION="40037529f72042cbb4f69ddb97b8bced"
+
+# Settings needed for AzureClusterIdentity used by the AzureCluster
+export AZURE_CLUSTER_IDENTITY_NAME="cluster-identity"
+export AZURE_CLUSTER_IDENTITY_NAMESPACE="$NAMESPACE"
+if [ -n "${AZURE_CLIENT_SECRET}" ] ; then
+    export AZURE_CLUSTER_IDENTITY_SECRET_NAME="cluster-identity-secret"
+    export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="$NAMESPACE"
+    export AZURE_CLUSTER_IDENTITY_SECRET_BASE64=$(echo -n "$AZURE_CLIENT_SECRET"|base64)
+fi
+
+export USE_EA=${USE_EA:-true}
+export EA_OIDC_USERNAME_CLAIM=${OIDC_USERNAME_CLAIM:-oid}
+export EA_OIDC_GROUPS_CLAIM=${OIDC_GROUPS_CLAIM:-groups}
+export EA_OIDC_PROVIDER_NAME=${CS_CLUSTER_NAME}-ea
+export EA_AZURE_TENANT_ID=${AZURE_TENANT_ID}
+export EA_AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
+export EA_DISABLE='#'
+[ "$USE_EA" = true ] && EA_DISABLE=''
+
+echo ENV=$ENV - AZURE_SUBSCRIPTION_NAME=${AZURE_SUBSCRIPTION_NAME} AZURE_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}, REGION=${REGION}
+echo AZURE_TENANT_ID=${AZURE_TENANT_ID}
+echo AZURE_CLIENT_ID=${AZURE_CLIENT_ID} AZURE_ASO_CLIENT_ID=${AZURE_ASO_CLIENT_ID} 
+mkdir -p "$GEN_OUTPUT"
+if [ -n "$CREATE_CREDENTIALS" ] ; then
+    if [ -n "${OICD_RESOURCE_GROUP}" ] ; then
+        # credentials using WorkloadIdentity
+        TEMPLATE_FILE_CRE=$(dirname $0)/credentials-wi-template.yaml
+    else
+        # credentials using ServicePrincipal
+        TEMPLATE_FILE_CRE=$(dirname $0)/credentials-sp-template.yaml
+    fi
+    echo creating: "$GEN_OUTPUT/credentials.yaml"
+    envsubst  < $TEMPLATE_FILE_CRE > "$GEN_OUTPUT/credentials.yaml"
+fi
+
+if [ "$ARO_HCP_VERSION" == "v1api20240610preview" ] ; then
+    ARO_TEMPLATE=${ARO_TEMPLATE:-'aro-template-v1api20240610preview.yaml'}
+fi
+ARO_TEMPLATE=${ARO_TEMPLATE:-'aro-template.yaml'}
+TEMPLATE_FILE_ARO=$(dirname $0)/${ARO_TEMPLATE}
+TEMPLATE_FILE_IS=$(dirname $0)/is-template.yaml
+
+
+if [ -z "$GEN_ASO" ] ; then
+    echo creating: "$GEN_OUTPUT/aro.yaml"
+    envsubst  < $TEMPLATE_FILE_ARO > "$GEN_OUTPUT/aro.yaml"
+else
+    echo creating: "$GEN_OUTPUT/is.yaml"
+    envsubst  < $TEMPLATE_FILE_IS > "$GEN_OUTPUT/is.yaml"
+
+    TEMPLATE_FILE_ASO=$(dirname $0)/aro-aso-template.yaml
+    TEMPLATE_FILE_ASO_EA=$(dirname $0)/aro-aso-ea-template.yaml
+    echo creating: "$GEN_OUTPUT/aro-aso.yaml"
+    envsubst  < $TEMPLATE_FILE_ASO > "$GEN_OUTPUT/aro-aso.yaml"
+    if [ "$USE_EA" == true ] ; then
+        echo creating: "$GEN_OUTPUT/aro-ea.yaml"
+        envsubst  < $TEMPLATE_FILE_ASO_EA > "$GEN_OUTPUT/aro-ea.yaml"
+    fi
+fi

--- a/scripts/aro-hcp/gen.sh
+++ b/scripts/aro-hcp/gen.sh
@@ -159,6 +159,7 @@ if [ -n "$CREATE_CREDENTIALS" ] ; then
     fi
     echo creating: "$GEN_OUTPUT/credentials.yaml"
     envsubst  < $TEMPLATE_FILE_CRE > "$GEN_OUTPUT/credentials.yaml"
+    chmod 600 "$GEN_OUTPUT/credentials.yaml"
 fi
 
 if [ "$ARO_HCP_VERSION" == "v1api20240610preview" ] ; then

--- a/scripts/aro-hcp/is-template.yaml
+++ b/scripts/aro-hcp/is-template.yaml
@@ -1,0 +1,860 @@
+# Equivalent to:
+# az group create --name "${RESOURCEGROUPNAME}" --location "${REGION}"
+# This YAML creates a Resource Group named "${RESOURCEGROUPNAME}" in the specified Azure region "${REGION}".
+apiVersion: resources.azure.com/v1api20200601
+kind: ResourceGroup
+metadata:
+  name: ${RESOURCEGROUPNAME}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+---
+# Equivalent to:
+# az network vnet create -n "${VNET}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a virtual network named "${VNET}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: network.azure.com/v1api20201101
+kind: VirtualNetwork
+metadata:
+  name: ${VNET}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  addressSpace:
+    addressPrefixes:
+      - 10.100.0.0/15
+---
+# Equivalent to:
+# az network nsg create -n "${NSG}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a Network Security Group (NSG) named "${NSG}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: network.azure.com/v1api20201101
+kind: NetworkSecurityGroup
+metadata:
+  name: ${NSG}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+---
+# Equivalent to:
+# az network vnet subnet create -n "${SUBNET}" -g "${RESOURCEGROUPNAME}" --vnet-name "${VNET}" --network-security-group "${NSG}"
+# This YAML creates a subnet named "${SUBNET}" in the "${VNET}" virtual network and associates it with the "${NSG}" Network Security Group.
+apiVersion: network.azure.com/v1api20201101
+kind: VirtualNetworksSubnet
+metadata:
+  name: ${VNET}-${SUBNET}
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${VNET}
+  addressPrefix: 10.100.76.0/24
+  azureName: ${SUBNET}
+  networkSecurityGroup:
+    reference:
+      name: ${NSG}
+      group: network.azure.com
+      kind: NetworkSecurityGroup
+---
+# Equivalent to:
+# az keyvault create --name "$KV" -g ${RESOURCEGROUPNAME} --location "${REGION}" --enable-rbac-authorization true
+# This YAML creates a key vault named "${KV}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: keyvault.azure.com/v1api20230701
+kind: Vault
+metadata:
+  name: "${KV}"
+  namespace: ${NAMESPACE}
+spec:
+  location: "${REGION}"
+  owner:
+    name: "${RESOURCEGROUPNAME}"
+  properties:
+    createMode: createOrRecover
+    enableRbacAuthorization: true
+    enabledForDiskEncryption: false
+    enabledForTemplateDeployment: false
+    enableSoftDelete: true
+    tenantId: "${AZURE_TENANT_ID}"
+    accessPolicies: [] 
+    sku:
+      family: A
+      name: standard
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+# Equivalent to:
+# az identity create -n "${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}" -g "${RESOURCEGROUPNAME}"
+# This YAML creates a managed identity named "${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}" in the "${RESOURCEGROUPNAME}" resource group.
+apiVersion: managedidentity.azure.com/v1api20230131
+kind: UserAssignedIdentity
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  location: ${REGION}
+  owner:
+    name: ${RESOURCEGROUPNAME}
+  operatorSpec:
+    configMaps:
+      principalId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: principalId
+      clientId:
+        name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+        key: clientId
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}-hcpclusterapiproviderroleid-subnet
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${VNET}-${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 88366f10-ed47-4cc0-9fab-c8a06148393e represents 'hcpClusterApiProviderRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-clusterapiazuremi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}-keyvaultcryptouserroleid-keyvault
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${KV}
+    group: keyvault.azure.com
+    kind: Vault
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 12338af0-0e69-4776-bea7-57ae8d297424 represents 'keyVaultCryptoUserRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/12338af0-0e69-4776-bea7-57ae8d297424
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-kmsmi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-cp-kms-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}-hcpcontrolplaneoperatorroleid-vnet
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${VNET}
+    group: network.azure.com
+    kind: VirtualNetwork
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # fc0c873f-45e9-4d0d-a7d1-585aab30c6ed represents 'hcpControlPlaneOperatorRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}-hcpcontrolplaneoperatorroleid-nsg
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${NSG}
+    group: network.azure.com
+    kind: NetworkSecurityGroup
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # fc0c873f-45e9-4d0d-a7d1-585aab30c6ed represents 'hcpControlPlaneOperatorRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-controlplanemi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-cp-control-plane-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}-cloudcontrollermanagerroleid-subnet
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${VNET}-${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # a1f96423-95ce-4224-ab27-4e3dc72facd4 represents 'cloudControllerManagerRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}-cloudcontrollermanagerroleid-nsg
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${NSG}
+    group: network.azure.com
+    kind: NetworkSecurityGroup
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # a1f96423-95ce-4224-ab27-4e3dc72facd4 represents 'cloudControllerManagerRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-cloudcontrollermanagermi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-controller-manager-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}-ingressoperatorroleid-subnet
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${VNET}-${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 0336e1d3-7a87-462b-b6db-342b63f7802c represents 'ingressOperatorRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0336e1d3-7a87-462b-b6db-342b63f7802c
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-ingressmi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-cp-ingress-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-diskcsidrivermi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-cp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-subnet
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${VNET}-${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-nsg
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${NSG}
+    group: network.azure.com
+    kind: NetworkSecurityGroup
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-filecsidrivermi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-cp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-imageregistrymi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-cp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}-networkoperatorroleid-subnet
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${VNET}-${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # be7a6435-15ae-4171-8f30-4a343eff9e8f represents 'networkOperatorRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}-networkoperatorroleid-vnet
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${VNET}
+    group: network.azure.com
+    kind: VirtualNetwork
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # be7a6435-15ae-4171-8f30-4a343eff9e8f represents 'networkOperatorRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-readerroleid-cloudnetworkconfigmi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-cp-cloud-network-config-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # acdd72a7-3385-48ef-bd42-f606fba81ae7 represents 'readerRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpdiskcsidrivermi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-dp-disk-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpfilecsidrivermi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-subnet
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${VNET}-${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}-filestorageoperatorroleid-nsg
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${NSG}
+    group: network.azure.com
+    kind: NetworkSecurityGroup
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # 0d7aedc0-15fd-4a67-a412-efad370c947e represents 'fileStorageOperatorRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-federatedcredentialsroleid-dpimageregistrymi
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}
+    group: managedidentity.azure.com
+    kind: UserAssignedIdentity
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # ef318e2a-8334-4a05-9e4a-295a196c6a6e represents 'federatedCredentialsRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-vnet
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${VNET}
+    group: network.azure.com
+    kind: VirtualNetwork
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-subnet
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${VNET}-${SUBNET}
+    group: network.azure.com
+    kind: VirtualNetworksSubnet
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+---
+apiVersion: authorization.azure.com/v1api20220401
+kind: RoleAssignment
+metadata:
+  name: ${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}-hcpservicemanagedidentityroleid-nsg
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${NSG}
+    group: network.azure.com
+    kind: NetworkSecurityGroup
+  principalIdFromConfig:
+    name: identity-map-${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}
+    key: principalId
+  principalType: ServicePrincipal
+  roleDefinitionReference:
+    # c0ff367d-66d8-445e-917c-583feb0ef0d4 represents 'hcpServiceManagedIdentityRoleId'
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4
+

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -149,6 +149,8 @@ build_for_config() {
         mkdir -p $WKDIR
         rm -rf "$project_dir"
         mkdir "$project_dir"
+        echo ================== CLONE:
+        echo git clone --depth=1 --branch="${BRANCH}" "${ORGREPO}/${PROJECT}" "${project_dir}"
         git clone --depth=1 --branch="${BRANCH}" "${ORGREPO}/${PROJECT}" "${project_dir}"
     fi
 

--- a/scripts/deploy-charts.sh
+++ b/scripts/deploy-charts.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
+set -o pipefail
 DO_INIT_KIND=${INIT_KIND:-true}
 DO_DEPLOY=${DO_DEPLOY:-true}
 DO_CHECK=${DO_CHECK:-true}
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+IMAGE_PULL_SECRET_B64=${IMAGE_PULL_SECRET_B64:-eyJhdXRocyI6e319}
+declare -A DEPLOYMENTS=()
 
 [ -s ./replace-params ] && . ./replace-params
 
@@ -24,40 +27,95 @@ else
 fi
 
 function set_namespace_and_t {
-    case "$PROJECT" in
-      cluster-api)
-        T="capi"
-        NAMESPACE="capi-system"
-        ;;
-      cluster-api-provider-azure)
-        T="capz"
-        NAMESPACE="capz-system"
-        ;;
-      cluster-api-provider-aws)
-        T="capa"
-        NAMESPACE="capa-system"
-        ;;
-    esac
+    DEPLOYMENTS=()
+    NAMESPACE=""
+    HELM_RELEASE_NAME=""
     if [ "$USE_K8S" = true ] ; then
         NAMESPACE="multicluster-engine"
     fi
+    case "$PROJECT" in
+      cluster-api)
+        T="capi"
+        NAMESPACE=${NAMESPACE:-"capi-system"}
+        DEPLOYMENTS[$NAMESPACE]="${T}-controller-manager"
+        if [ "$USE_KIND" != true -a "$USE_K8S" != true ] ; then
+            DEPLOYMENTS[$NAMESPACE]="${DEPLOYMENTS[$NAMESPACE]} mce-capi-webhook-config"
+        fi
+        ;;
+      cluster-api-provider-azure)
+        T="capz"
+        NAMESPACE=${NAMESPACE:-"capz-system"}
+        DEPLOYMENTS[$NAMESPACE]="${T}-controller-manager azureserviceoperator-controller-manager"
+        ;;
+      cluster-api-provider-aws)
+        T="capa"
+        NAMESPACE=${NAMESPACE:-"capa-system"}
+        DEPLOYMENTS[$NAMESPACE]="${T}-controller-manager"
+        ;;
+      cluster-api-provider-metal3)
+        T="capm3"
+        NAMESPACE=${NAMESPACE:-"capm3-system"}
+        DEPLOYMENTS[$NAMESPACE]="mce-${T}-controller-manager"
+        ;;
+      cluster-api-provider-openshift-assisted)
+        T="capoa"
+        DEPLOYMENTS['capoa-bootstrap-system']="capoa-bootstrap-controller-manager"
+        DEPLOYMENTS['capoa-controlplane-system']="capoa-controlplane-controller-manager"
+        NAMESPACE=${NAMESPACE:-"capoa-controlplane-system capoa-bootstrap-system"}
+        DEPLOYMENTS[$NAMESPACE]="capoa-bootstrap-controller-manager capoa-controlplane-controller-manager"
+        ;;
+      aro-mockup-proxy)
+        T="aro-mockup-proxy"
+        HELM_RELEASE_NAME="aro-mockup-proxy"
+        NAMESPACE=${NAMESPACE:-"capz-system"}
+        DEPLOYMENTS[$NAMESPACE]="${T}"
+        ;;
+    esac
 }
 
 CHARTS=$(echo cluster-api $*|tr ' ' '\n'|sort -u|tr '\n' ' ')
 
+if [ "$ARO_NULL_PROVISIONING" = "true" ] ; then
+    CHARTS=$(echo aro-mockup-proxy $CHARTS|tr ' ' '\n'|sort -u|tr '\n' ' ')
+fi
+
 if [ "$DO_DEPLOY" = true ] ; then
     for PROJECT in $CHARTS ; do
         CHART="charts/$PROJECT$CHART_SUFFIX"
-        [ -f $CHART/Chart.yaml ] || continue
+        [ -f $CHART/Chart.yaml ] || {
+            echo "!!!!!!!!! SKIP DEPLOY: $CHART "
+            continue
+        }
         set_namespace_and_t
         echo ========= deploy: $CHART "using context: $KUBE_CONTEXT"
         echo "        PROJECT: $PROJECT"
         echo "      NAMESPACE: $NAMESPACE"
-        if [ "$NAMESPACE" = "multicluster-engine" ] ; then
-            kubectl $KUBE_CONTEXT get namespace "$NAMESPACE" >/dev/null 2>&1 || kubectl $KUBE_CONTEXT create namespace "$NAMESPACE" 
+        kubectl $KUBE_CONTEXT get namespace "$NAMESPACE" >/dev/null 2>&1 || kubectl $KUBE_CONTEXT create namespace "$NAMESPACE" 
+        # Create prerequisites for aro-mockup-proxy
+        if [ "$PROJECT" = "aro-mockup-proxy" ] ; then
+            KUBECONFIG_FILE=${MOCK_KUBECONFIG_FILE:-"${SCRIPT_DIR}/../aro-mockup-proxy/workload-kubeconfig.yaml"}
+            if [ -f "$KUBECONFIG_FILE" ] ; then
+                echo "  Creating mockup-proxy-kubeconfig secret from $KUBECONFIG_FILE"
+                kubectl $KUBE_CONTEXT -n "$NAMESPACE" create secret generic mockup-proxy-kubeconfig \
+                    --from-file=workload-kubeconfig.yaml="$KUBECONFIG_FILE" \
+                    --dry-run=client -o yaml | kubectl $KUBE_CONTEXT -n "$NAMESPACE" apply -f -
+            else
+                echo "  WARNING: kubeconfig file not found at $KUBECONFIG_FILE, requestAdminCredential will fail"
+            fi
         fi
-        echo "      HELM ARGS: --set Release.Namespace=$NAMESPACE" ${helm_add_args_a[$T]}
-        helm template $CHART --include-crds --namespace "$NAMESPACE" --set "Release.Namespace=$NAMESPACE" ${helm_add_args_a[$T]}|kubectl $KUBE_CONTEXT apply -f - --server-side --force-conflicts
+        # Pass DEV_ENDPOINT to aro-mockup-proxy chart when set
+        DEV_ENDPOINT_ARG=""
+        if [ "$PROJECT" = "aro-mockup-proxy" -a -n "$DEV_ENDPOINT" ] ; then
+            DEV_ENDPOINT_ARG="--set config.devEndpoint=$DEV_ENDPOINT"
+            echo "  DEV_ENDPOINT: $DEV_ENDPOINT (hcpOpenShiftCluster requests will be forwarded)"
+        fi
+        echo "      HELM ARGS: --set Release.Namespace=$NAMESPACE" ${helm_add_args_a[$T]} $DEV_ENDPOINT_ARG
+        HELM_NAME_ARG=""
+        [ -n "$HELM_RELEASE_NAME" ] && HELM_NAME_ARG="--name-template=$HELM_RELEASE_NAME"
+        helm template $HELM_NAME_ARG $CHART --include-crds --namespace "$NAMESPACE" \
+            --set imagePullSecret=${IMAGE_PULL_SECRET_B64} \
+            --set "Release.Namespace=$NAMESPACE" \
+            ${helm_add_args_a[$T]} $DEV_ENDPOINT_ARG|kubectl $KUBE_CONTEXT -n "$NAMESPACE" apply -f - --server-side --force-conflicts
         echo
     done
 fi
@@ -68,23 +126,56 @@ if [ "$DO_CHECK" = true ] ; then
         CHART="charts/$PROJECT$CHART_SUFFIX"
         [ -f $CHART/Chart.yaml ] || continue
         set_namespace_and_t
-        echo "Waiting for ${T} controller (in $NAMESPACE namespace):"
-        kubectl $KUBE_CONTEXT events -n "$NAMESPACE" --watch &
-        CH_PID=$!
-        kubectl $KUBE_CONTEXT -n "$NAMESPACE" wait deployment/${T}-controller-manager --for condition=Available=True  --timeout=10m
-        if [ "${T}" = capz ] ; then
-            echo "Waiting for azureserviceoperator controller (in $NAMESPACE namespace):"
-            kubectl $KUBE_CONTEXT -n "$NAMESPACE" wait deployment/azureserviceoperator-controller-manager --for condition=Available=True  --timeout=10m
-        fi
-        if [ "${T}" = capi ] ; then
-            if [ "$USE_KIND" != true -a "$USE_K8S" != true ] ; then
-                echo "Waiting for mce-capi-webhook-config controller (in $NAMESPACE namespace):"
-                kubectl $KUBE_CONTEXT -n "$NAMESPACE" wait deployment/mce-capi-webhook-config --for condition=Available=True  --timeout=10m
-            fi
-        fi
-        kill $CH_PID
-        echo
+        for i in $NAMESPACE; do
+            for D in ${DEPLOYMENTS[$i]} ; do
+                echo "Waiting for $D controller (in $i namespace):"
+                kubectl $KUBE_CONTEXT events -n "$i" --watch &
+                CH_PID=$!
+                trap "kill $CH_PID 2>/dev/null || true" EXIT
+                kubectl $KUBE_CONTEXT -n "$i" wait deployment/${D} --for condition=Available=True  --timeout=10m
+                kill $CH_PID 2>/dev/null || true
+                echo
+            done
+        done
     done
+fi
+
+# Configure ARO null-provisioning mode
+if [ "$ARO_NULL_PROVISIONING" = "true" ] && echo "$CHARTS" | grep -q "aro-mockup-proxy"; then
+    echo "========= Configuring ARO null-provisioning mode ========="
+
+    # Get the mockup proxy service endpoint (in capz-system namespace)
+    MOCKUP_PROXY_SERVICE="aro-mockup-proxy.capz-system.svc.cluster.local:8443"
+    echo "Mockup proxy service: $MOCKUP_PROXY_SERVICE"
+
+    # Configure Azure Service Operator to use the mockup proxy
+    # ASO reads these env vars from the aso-controller-settings secret via valueFrom,
+    # so we patch the secret rather than the deployment to avoid value/valueFrom conflicts
+    if echo "$CHARTS" | grep -q "cluster-api-provider-azure"; then
+        echo "Patching aso-controller-settings secret to use mockup proxy..."
+
+        kubectl $KUBE_CONTEXT -n capz-system patch secret aso-controller-settings \
+            --type merge -p "{\"stringData\":{\"AZURE_RESOURCE_MANAGER_ENDPOINT\":\"https://$MOCKUP_PROXY_SERVICE\",\"AZURE_RESOURCE_MANAGER_AUDIENCE\":\"https://management.azure.com/\"}}" \
+            || echo "Warning: Failed to patch aso-controller-settings secret"
+
+        # Patch ASO deployment to trust the mockup proxy CA certificate and restart
+        # Skip if already patched (idempotent)
+        if ! kubectl $KUBE_CONTEXT -n capz-system get deployment azureserviceoperator-controller-manager -o jsonpath='{.spec.template.spec.volumes[*].name}' | grep -q mockup-proxy-ca; then
+            echo "Patching ASO deployment to trust mockup proxy CA..."
+            kubectl $KUBE_CONTEXT -n capz-system patch deployment azureserviceoperator-controller-manager --type=json -p='[
+              {"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"mockup-proxy-ca","secret":{"secretName":"aro-mockup-proxy-tls","items":[{"key":"ca.crt","path":"ca.crt"}]}}},
+              {"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"mockup-proxy-ca","mountPath":"/etc/ssl/certs/aro-mockup-proxy-ca.crt","subPath":"ca.crt","readOnly":true}},
+              {"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"SSL_CERT_FILE","value":"/etc/ssl/certs/aro-mockup-proxy-ca.crt"}}
+            ]'
+        else
+            echo "ASO deployment already patched with mockup proxy CA, skipping"
+        fi
+
+        echo "✓ Azure Service Operator configured to use mockup proxy"
+        echo "  ARM endpoint: https://$MOCKUP_PROXY_SERVICE"
+    fi
+
+    echo "========= ARO null-provisioning mode configured ========="
 fi
 
 

--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -11,10 +11,31 @@ set -e
 #   KIND_CLUSTER_NAME - Name of the kind cluster (default: aso2)
 
 KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-${1:-aso2}}
+HELM_INSTALL_TIMEOUT=${HELM_INSTALL_TIMEOUT:-10m}
+KIND_NODE_IMAGE=${KIND_NODE_IMAGE:-kindest/node:v1.31.14}
 
 if ! (kind get clusters 2>/dev/null|grep -q '^'"$KIND_CLUSTER_NAME"'$') ; then
-    kind create cluster --name "$KIND_CLUSTER_NAME" --image="kindest/node:v1.31.0"
+    SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    if [ -z "$KIND_CFG_NAME" ] ; then
+        if [ -n "$DOCKER_SECRETS" ] ; then
+            KIND_CFG_NAME="$SCRIPT_DIR/kind-config-$KIND_CLUSTER_NAME.yaml"
+cat << EOF > "$KIND_CFG_NAME"
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: $DOCKER_SECRETS
+    containerPath: /var/lib/kubelet/config.json
+EOF
+        fi
+    fi
+    KIND_OPTS="" 
+    if [ -f "$KIND_CFG_NAME" ] ; then
+        KIND_OPTS="$KIND_OPTS --config=$KIND_CFG_NAME"
+    fi
+    kind create cluster --name "$KIND_CLUSTER_NAME" --image="$KIND_NODE_IMAGE" $KIND_OPTS
     helm repo add jetstack https://charts.jetstack.io --force-update
     helm repo update
-    helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true --wait --timeout 5m
+    helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true --wait --timeout $HELM_INSTALL_TIMEOUT
 fi

--- a/scripts/sync2chart.sh
+++ b/scripts/sync2chart.sh
@@ -67,6 +67,16 @@ _update_chart_yaml() {
     local chart_version="$2"
     local chart_app_version="$3"
     local chart_values_image_tag="$4"
+    local suffix="$5"
+    if [ -n "$suffix" ] ; then
+        local base_chartdir="${chartdir%${suffix}}"
+        for i in Chart.yaml values.yaml ; do
+            if [ ! -f "$chartdir/$i" -a -f "$base_chartdir/$i" ] ; then
+                echo "copy : $base_chartdir/$i $chartdir/$i"
+                cp -a "$base_chartdir/$i" "$chartdir/$i"
+            fi
+        done
+    fi
     echo "updating versions in: $chartdir/Chart.yaml $chartdir/values.yaml"
     echo "* chart version: ${chart_version}"
     echo "* chart app version: ${chart_app_version}"
@@ -91,7 +101,7 @@ update_chart_versions() {
 
    local _chartdir="${chartdir}$suffix"
    [ -d "$_chartdir" ] || return 0
-   _update_chart_yaml "$_chartdir" "$chart_version" "$chart_app_version" "$chart_values_image_tag"
+   _update_chart_yaml "$_chartdir" "$chart_version" "$chart_app_version" "$chart_values_image_tag" "$suffix"
    echo "updated chart versions in $_chartdir"
 }
 
@@ -147,17 +157,18 @@ CHARTDIR="$PROJECT_ROOT/charts/$PROJECT"
 NEWCHART="$(realpath "$BUILTDIR")/new-chart.yml"
 
 if [ "$SYNC2CHARTS" ] ;then
+    IS_UPDATED=false
     for suffix in "" "-k8s" "-kind" ; do
+        [ -d "$PROJECT_ROOT/config$suffix/$PROJECT" ] || continue # not defined/required
+        echo ========== Syncing: "$PROJECT_ROOT/config$suffix/$PROJECT"
         sync_chart_files "$BUILTDIR" "$CHARTDIR" "$suffix" 
         update_chart_versions "$CHARTDIR" "$CHART_VERSION" "$CHART_APP_VERSION" "$CHART_VALUES_IMAGE_TAG" "$suffix"
         generate_helm_template "$CHARTDIR" "$NEWCHART" "$suffix"
+        if [ $(git diff --name-only "$CHARTDIR$suffix" $SRC_PROJECT_FILE|wc -l) -gt 0 ] ; then
+            IS_UPDATED=true
+        fi
     done
 
-
-    IS_UPDATED=false
-    if [ $(git diff --name-only "$CHARTDIR" $SRC_PROJECT_FILE|wc -l) -gt 0 ] ; then
-        IS_UPDATED=true
-    fi
     echo "updated_$PROJECT=$IS_UPDATED"
     if [ -n "$GITHUB_OUTPUT" ] ; then
         # when started under github workflow


### PR DESCRIPTION
## Summary
- Add ARO HCP scripts, templates and configuration for backplane-2.11
- Add mce-capi-webhook-config chart templates and kustomize overlays
- Add CAPZ pull-secret and kustomization support
- Update deploy-charts, setup-kind-cluster, sync2chart and replace-params scripts

Jira: https://issues.redhat.com/browse/ARO-26782

## Test plan
- [ ] Verify ARO HCP scripts work with backplane-2.11 environment
- [ ] Validate chart deployment with updated deploy-charts.sh
- [ ] Test kind cluster setup with updated setup-kind-cluster.sh