### PR TITLE
add build-docker-%-chart pattern to build individual charts in Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ CLUSTERCTL_PLATFORM := linux-amd64
 
 CONTAINER_ENGINE ?= docker
 
+build-docker-%-chart:
+	$(CONTAINER_ENGINE) --version|grep -q podman && MOUNT_FLAGS=",Z" ; \
+	$(CONTAINER_ENGINE) run --rm --interactive --workdir=/workspace --mount=type=bind,src=./,target=/workspace$${MOUNT_FLAGS} docker.io/library/golang:1.24.0 make build-$*-chart TOOLS_DIR=hack-docker/tools
+
 build-%-chart: $(YQ) $(KUSTOMIZE) $(CLUSTERCTL) $(HELM)
 	(export YQ=$(YQ) CLUSTERCTL=$(CLUSTERCTL) KUSTOMIZE=$(KUSTOMIZE) HELM=$(HELM); $(MAKE) -C ./charts $@)
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ See [this documentation](./doc/Adding-NewProvider.md) if you want to add a new p
     * A Docker container is used for a more unified build environment.
     * Use this if you encounter issues with the standard `make` command.
     * NOTE: if we want to use a different container engine, set CONTAINER_ENGINE environment variable (i.e. `export CONTAINER_EINGINE=podman`)
+    * To build a single chart in Docker:
+      ```sh
+      make build-docker-cluster-api-provider-aws-chart
+      ```
 * To check chart deployment:
   ```sh
    make test-charts-crc


### PR DESCRIPTION
## Summary
  Add `build-docker-%-chart` pattern rule to enable building individual Helm charts in Docker containers.

  ## Why
  Previously, `make build-docker` only supported building all charts at once. 

  Example usage:
  ```bash
  make build-docker-cluster-api-provider-aws-chart
```