### PR TITLE
ARO-26783 - fix variable name in replace-params for backplane-5.1

### DIFF
--- a/replace-params
+++ b/replace-params
@@ -1,4 +1,4 @@
-if [ "$ARO_REPO_DIR" = "backplane-5.1" ] ; then
+if [ "$ARO_REPO_BRANCH" = "backplane-5.1" ] ; then
     AZURE_TAG="5.1-dev"
     CAPI_TAG="v4.22" # TODO: -> v.5.1
     WH_TAG="5.0-dev" # TODO: -> 5.1-dev


### PR DESCRIPTION
## Summary
- Fix variable name in `replace-params`: use `ARO_REPO_BRANCH` instead of `ARO_REPO_DIR` to correctly detect the backplane-5.1 branch
- This is a follow-up fix to #680 / #679 which introduced the backplane-5.1 image selection logic

## JIRA
[ARO-26783](https://issues.redhat.com/browse/ARO-26783)

## Test plan
- [ ] Verify `replace-params` correctly selects backplane-5.1 images when `ARO_REPO_BRANCH=backplane-5.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARO-26783]: https://redhat.atlassian.net/browse/ARO-26783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ