### PR TITLE
ARO-26748 - prepare cluster-api-installer for PR checks by capi-tests

### DIFF
--- a/replace-params
+++ b/replace-params
@@ -1,5 +1,29 @@
+AZURE_CAPZ_URL="quay.io/acm-d/cluster-api-provider-azure-rhel9"
+AZURE_ASO_URL="quay.io/acm-d/azure-service-operator-rhel9"
+
+AZURE_TAG="2.11-dev"
+RELEASE_EXT="211"
+CAPI_TAG="v4.21"
+WH_TAG="2.11-dev"
+
+
+AZURE_CAPZ_TAG="$AZURE_TAG"
+AZURE_ASO_TAG="$AZURE_TAG"
+
+if [ -n "$CAPZ_PR_NO" ] ; then
+    AZURE_CAPZ_URL="quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-azure-mce-$RELEASE_EXT"
+    AZURE_CAPZ_TAG="${AZURE_CAPZ_TAG%%-dev}.0-pr-$CAPZ_PR_NO"
+fi
+
+if [ -n "$ASO_PR_NO" ] ; then
+    AZURE_ASO_URL=quay.io/redhat-user-workloads/crt-redhat-acm-tenant/azure-service-operator-mce-$RELEASE_EXT
+    AZURE_ASO_TAG="${AZURE_ASO_TAG%%-dev}.0-pr-$ASO_PR_NO"
+fi
+
 declare -A helm_add_args_a=(
-  [capi]="--set manager.image.url=quay.io/acm-d/ose-cluster-api-rhel9            --set webhook.image.url=quay.io/acm-d/mce-capi-webhook-config-rhel9 --set manager.image.tag=v4.21 --set webhook.image.tag=2.11-dev"
-  [capz]="--set manager.image.url=quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-azure-mce-211 --set aso.image.url=quay.io/redhat-user-workloads/crt-redhat-acm-tenant/azure-service-operator-mce-211 --set manager.image.tag=2.11.0-latest --set aso.image.tag=2.11.0-latest"
+  [capi]="--set manager.image.url=quay.io/acm-d/ose-cluster-api-rhel9            --set webhook.image.url=quay.io/acm-d/mce-capi-webhook-config-rhel9 --set manager.image.tag=${CAPI_TAG} --set webhook.image.tag=${WH_TAG}"
+  [capz]="--set manager.image.url=${AZURE_CAPZ_URL} --set aso.image.url=${AZURE_ASO_URL} --set manager.image.tag=${AZURE_CAPZ_TAG} --set aso.image.tag=${AZURE_ASO_TAG}"
+  [capa]="--set manager.image.url=quay.io/acm-d/cluster-api-provider-aws-rhel9   --set manager.image.tag=latest"
+  [capm3]="--set manager.image.url=quay.io/acm-d/ose-baremetal-cluster-api-controllers-rhel9"
 )
 

--- a/replace-params
+++ b/replace-params
@@ -16,7 +16,7 @@ if [ -n "$CAPZ_PR_NO" ] ; then
 fi
 
 if [ -n "$ASO_PR_NO" ] ; then
-    AZURE_ASO_URL=quay.io/redhat-user-workloads/crt-redhat-acm-tenant/azure-service-operator-mce-$RELEASE_EXT
+    AZURE_ASO_URL="quay.io/redhat-user-workloads/crt-redhat-acm-tenant/azure-service-operator-mce-$RELEASE_EXT"
     AZURE_ASO_TAG="${AZURE_ASO_TAG%%-dev}.0-pr-$ASO_PR_NO"
 fi
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #688 to backplane-2.11
- Add support for PR-based image overrides in `replace-params` for CAPZ and ASO components
- When `CAPZ_PR_NO` or `ASO_PR_NO` environment variables are set, use PR-specific images from `quay.io/redhat-user-workloads/crt-redhat-acm-tenant/` instead of the default `quay.io/acm-d/` images
- Add `RELEASE_EXT` variable to distinguish between backplane release image paths
- This enables automated PR testing by capi-tests workflows

## Test plan
- [ ] Verify `replace-params` works without `CAPZ_PR_NO` / `ASO_PR_NO` set (default behavior unchanged)
- [ ] Verify setting `CAPZ_PR_NO=123` overrides the CAPZ image URL and tag correctly
- [ ] Verify setting `ASO_PR_NO=456` overrides the ASO image URL and tag correctly
- [ ] Verify correct `RELEASE_EXT` for backplane-2.11 branch

Jira: https://issues.redhat.com/browse/ARO-26748