### PR TITLE
pin actions/checkout to SHA and ff to multiple backplane branches

### DIFF
--- a/.github/workflows/ffwd-branch.yaml
+++ b/.github/workflows/ffwd-branch.yaml
@@ -14,11 +14,11 @@ jobs:
   fast-forward:
     runs-on: ubuntu-latest
     env:
-      TARGET_BRANCH: backplane-5.0
+      TARGET_BRANCHES: backplane-5.0 backplane-5.1
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,10 +26,13 @@ jobs:
       - name: Fetch all branches
         run: git fetch --all
 
-      - name: Fast-forward main commits into  ${{ env.TARGET_BRANCH }}
+      - name: Fast-forward main commits into backplane branches
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          git checkout "${TARGET_BRANCH}"
-          git merge --ff-only origin/main
-          git push origin "${TARGET_BRANCH}"
+          for branch in ${TARGET_BRANCHES}; do
+            echo "--- Fast-forwarding ${branch} ---"
+            git checkout "${branch}"
+            git merge --ff-only "${{ github.sha }}"
+            git push origin "${branch}"
+          done


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` to full commit SHA (`v6.0.2`) for supply-chain security instead of mutable `@v6` tag
- Fast-forward to multiple backplane branches (`backplane-5.0`, `backplane-5.1`) in a loop instead of a single branch
- Use `github.sha` for merge source instead of `origin/main`

## Test plan
- [ ] Verify workflow triggers on push to `main`
- [ ] Verify fast-forward succeeds to both `backplane-5.0` and `backplane-5.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)