### PR TITLE
ARO-27134 - Add USE_KUBECONFIG support to deploy charts against an external cluster

### DIFF
--- a/scripts/deploy-charts.sh
+++ b/scripts/deploy-charts.sh
@@ -13,12 +13,16 @@ declare -A DEPLOYMENTS=()
 if [ "$USE_KIND" = true -o "$USE_K8S" = true ] ; then
     [ "$USE_KIND" = true ] && CHART_SUFFIX="-kind"
     [ "$USE_K8S" = true ] && CHART_SUFFIX="-k8s"
-    KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-aso2}
-    KUBE_CONTEXT="--context=kind-$KIND_CLUSTER_NAME"
-    echo "setting: KUBE_CONTEXT=$KUBE_CONTEXT"
-    if [ "$DO_INIT_KIND" = true ] ; then
-        echo "checking if the cluster exists: KIND_CLUSTER_NAME=$KIND_CLUSTER_NAME"
-        ${SCRIPT_DIR}/setup-kind-cluster.sh
+    if [ -n "$USE_KUBECONFIG" ] ; then
+        export KUBE_CONFIG="$USE_KUBECONFIG"
+    else
+        KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-aso2}
+        KUBE_CONTEXT="--context=kind-$KIND_CLUSTER_NAME"
+        echo "setting: KUBE_CONTEXT=$KUBE_CONTEXT"
+        if [ "$DO_INIT_KIND" = true ] ; then
+            echo "checking if the cluster exists: KIND_CLUSTER_NAME=$KIND_CLUSTER_NAME"
+            ${SCRIPT_DIR}/setup-kind-cluster.sh
+        fi
     fi
 else
     OCP_CONTEXT=${OCP_CONTEXT:-crc-admin}


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/ARO-27134

## Summary
- When `USE_KIND=true` or `USE_K8S=true` is used together with `USE_KUBECONFIG=<file>`, the provided kubeconfig is used instead of creating a local KIND cluster.
- This enables deploying charts against an existing external cluster (e.g. AKS).

## Test plan
- [ ] Run with `USE_KIND=true USE_KUBECONFIG=<path>` and verify it uses the provided kubeconfig
- [ ] Run with `USE_KIND=true` without `USE_KUBECONFIG` and verify KIND cluster setup still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)