### PR TITLE
ARO-27585 - document that imageDigestMirrors changes trigger node pool rollout

### DIFF
--- a/cluster-api-operator/README.md
+++ b/cluster-api-operator/README.md
@@ -67,6 +67,12 @@ The CAPZ release must include CRDs for the ARO HCP API version you plan to use:
 To migrate from `v1api20240610preview` to `v1api20251223preview`, see
 [Migration Guide](../doc/aro-hcp-api-v1api20251223preview-migration.md).
 
+> **Warning:** The `v1api20251223preview` API introduces an optional `imageDigestMirrors` field.
+> Any change to this field (adding, removing, or modifying an entry) on a running cluster will
+> trigger a **rolling replacement of all nodes across all existing NodePools**. See the
+> [Updating Cluster Configuration](../doc/ARO-capz.md#updating-cluster-configuration) section
+> for details.
+
 The new release must include updated `infrastructure-components.yaml` with CRDs for:
 - `hcpopenshiftclusters.redhatopenshift.azure.com` (v1api20251223preview)
 - `hcpopenshiftclustersnodepools.redhatopenshift.azure.com` (v1api20251223preview)

--- a/doc/ARO-capz.md
+++ b/doc/ARO-capz.md
@@ -25,8 +25,8 @@ We expect the following:
 
 1. Check out the deployment:
 ```
-git clone -b backplane-2.11 https://github.com/stolostron/cluster-api-installer.git backplane-2.11
-cd backplane-2.11
+git clone -b backplane-2.17 https://github.com/stolostron/cluster-api-installer.git backplane-2.17
+cd backplane-2.17
 ```
 
 2. The next command will prepare an instance of a kind cluster (with cert manager, CAPI, CAPZ and ASO):
@@ -35,7 +35,7 @@ KIND_CLUSTER_NAME=capz-stage ./scripts/deploy-charts-kind-capz.sh
 ```
 Please keep the `USER` value shorter than 5 charasters and `KIND_CLUSTER_NAME` shorter than 10 characters.
 
-3. Edit the variables in the script (if needed): ./doc/aro-hcp-scripts/aro-hcp-gen.sh
+3. Edit the variables in the script (if needed): ./scripts/aro-hcp/gen.sh
 ```
 export USER=${USER:-user1}
 export CS_CLUSTER_NAME=${CS_CLUSTER_NAME:-$USER-$ENV}
@@ -56,13 +56,13 @@ export REGION=${REGION:-westus3}
 
 Simple deployment for stage:
 ```
-ENV=stage ./doc/aro-hcp-scripts/aro-hcp-gen.sh aro-stage
+ENV=stage ./scripts/aro-hcp/gen.sh aro-stage
 ```
 
 For pruduction we can use e.g.:
 ```
 REGION="switzerlandnorth" USER=mveber4 AZURE_SUBSCRIPTION_NAME="974ebd46-8ad3-41e3-afef-7ef25fd5c371" \
-ENV=prod ./doc/aro-hcp-scripts/aro-hcp-gen.sh aro-prod
+ENV=prod ./scripts/aro-hcp/gen.sh aro-prod
 ```
 
 5. Apply the YAML files with resources (YAMLs from the directory in the specified order):
@@ -93,6 +93,19 @@ watch -n 5 --color --no-wrap ./bin/clusterctl describe cluster "<your-cluster-na
 ```
 KUBECONFIG=/tmp/kc.yaml oc get nodes
 ```
+
+## Updating Cluster Configuration
+
+### Image Digest Mirrors
+
+> **Warning:** Any change to `imageDigestMirrors` (adding, removing, or modifying an entry) will trigger a **rolling replacement of all nodes across all existing NodePools**. This applies to updates made via the CAPZ `AROControlPlane` CR or the ARM API.
+>
+> At initial cluster creation this has no impact because no NodePools exist yet. However, updating `imageDigestMirrors` on a running cluster will cause every node in every NodePool to be replaced in a rolling fashion. If workloads use PodDisruptionBudgets that block drains, the rollout can stall indefinitely.
+>
+> **Before updating `imageDigestMirrors` on a live cluster:**
+> - Plan for a maintenance window — all NodePools will roll simultaneously.
+> - Verify that PodDisruptionBudgets allow at least one node to drain at a time.
+> - Batch all mirror changes into a single update to avoid multiple successive rollouts.
 
 ## External Authentication Configuration
 

--- a/doc/ARO-capz.md
+++ b/doc/ARO-capz.md
@@ -33,7 +33,7 @@ cd backplane-2.17
 ```
 KIND_CLUSTER_NAME=capz-stage ./scripts/deploy-charts-kind-capz.sh
 ```
-Please keep the `USER` value shorter than 5 charasters and `KIND_CLUSTER_NAME` shorter than 10 characters.
+Please keep the `USER` value shorter than 5 characters and `KIND_CLUSTER_NAME` shorter than 10 characters.
 
 3. Edit the variables in the script (if needed): ./scripts/aro-hcp/gen.sh
 ```

--- a/doc/ARO-capz.md
+++ b/doc/ARO-capz.md
@@ -59,7 +59,7 @@ Simple deployment for stage:
 ENV=stage ./scripts/aro-hcp/gen.sh aro-stage
 ```
 
-For pruduction we can use e.g.:
+For production we can use e.g.:
 ```
 REGION="switzerlandnorth" USER=mveber4 AZURE_SUBSCRIPTION_NAME="974ebd46-8ad3-41e3-afef-7ef25fd5c371" \
 ENV=prod ./scripts/aro-hcp/gen.sh aro-prod

--- a/doc/aro-hcp-api-v1api20251223preview-migration.md
+++ b/doc/aro-hcp-api-v1api20251223preview-migration.md
@@ -195,6 +195,8 @@ properties:
         - "mirror2.example.com/my-repo"
 ```
 
+> **Warning:** Any change to `imageDigestMirrors` (adding, removing, or modifying an entry) on a running cluster will trigger a **rolling replacement of all nodes across all existing NodePools**. Plan for a maintenance window and verify that PodDisruptionBudgets allow drains to proceed. Batch all mirror changes into a single update to avoid multiple successive rollouts.
+
 ## HcpOpenShiftClustersNodePool Changes
 
 ### 1. OS Disk Type (new optional field)

--- a/doc/aro-hcp-api-v1api20251223preview-migration.md
+++ b/doc/aro-hcp-api-v1api20251223preview-migration.md
@@ -195,7 +195,7 @@ properties:
         - "mirror2.example.com/my-repo"
 ```
 
-> **Warning:** Any change to `imageDigestMirrors` (adding, removing, or modifying an entry) on a running cluster will trigger a **rolling replacement of all nodes across all existing NodePools**. Plan for a maintenance window and verify that PodDisruptionBudgets allow drains to proceed. Batch all mirror changes into a single update to avoid multiple successive rollouts.
+> **Warning:** Any change to `imageDigestMirrors` (adding, removing, or modifying an entry) on a running cluster will trigger a **rolling replacement of all nodes across all existing NodePools**. Plan for a maintenance window and verify that PodDisruptionBudgets allow drains to proceed. Batch all mirror changes into a single update to avoid multiple successive rollouts. See [Updating Cluster Configuration](ARO-capz.md#updating-cluster-configuration) for full guidance.
 
 ## HcpOpenShiftClustersNodePool Changes
 


### PR DESCRIPTION
## Summary
- Add warnings to three docs that `imageDigestMirrors` changes trigger rolling replacement of all nodes across all existing NodePools
- Fix stale references in `doc/ARO-capz.md`: branch `backplane-2.11` → `backplane-2.17`, script path `doc/aro-hcp-scripts/aro-hcp-gen.sh` → `scripts/aro-hcp/gen.sh`

**Files changed:**
- `doc/ARO-capz.md` — new "Updating Cluster Configuration" section with full warning
- `doc/aro-hcp-api-v1api20251223preview-migration.md` — inline warning after `imageDigestMirrors` example
- `cluster-api-operator/README.md` — warning in API Version Support section with cross-link

**Context:** Customer incident itn-2026-00188 (IBM/Adobe) — updating `imageDigestMirrors` triggered full nodepool rolling replacement; 7/10 pools stalled on PDB-blocked drains for 14+ days.

**Note:** The three changed files are identical between `main` and `backplane-2.17`, so this commit can be cherry-picked to `main` as well.

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify cross-link from `cluster-api-operator/README.md` to `doc/ARO-capz.md#updating-cluster-configuration` works

Jira: https://redhat.atlassian.net/browse/ARO-27585