### PR TITLE
ARO-27593: Make role assignment names unique per Boskos MSI pool

### DIFF
--- a/scripts/aro-hcp/aro-template-roleassignments-ref.yaml
+++ b/scripts/aro-hcp/aro-template-roleassignments-ref.yaml
@@ -2,7 +2,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_CLUSTER_API_AZURE}-hcpclusterapiproviderroleid-subnet
+      name: ${MI_CLUSTER_API_AZURE}-hcpclusterapiproviderroleid-subnet-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -22,7 +22,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-readerroleid-clusterapiazuremi
+      name: ${MI_SERVICE}-readerroleid-clusterapiazuremi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -42,7 +42,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_KMS}-keyvaultcryptouserroleid-keyvault
+      name: ${MI_KMS}-keyvaultcryptouserroleid-keyvault-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -62,7 +62,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-readerroleid-kmsmi
+      name: ${MI_SERVICE}-readerroleid-kmsmi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -82,7 +82,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_CONTROL_PLANE}-hcpcontrolplaneoperatorroleid-vnet
+      name: ${MI_CONTROL_PLANE}-hcpcontrolplaneoperatorroleid-vnet-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -102,7 +102,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_CONTROL_PLANE}-hcpcontrolplaneoperatorroleid-nsg
+      name: ${MI_CONTROL_PLANE}-hcpcontrolplaneoperatorroleid-nsg-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -122,7 +122,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-readerroleid-controlplanemi
+      name: ${MI_SERVICE}-readerroleid-controlplanemi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -142,7 +142,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_CLOUD_CONTROLLER_MANAGER}-cloudcontrollermanagerroleid-subnet
+      name: ${MI_CLOUD_CONTROLLER_MANAGER}-cloudcontrollermanagerroleid-subnet-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -162,7 +162,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_CLOUD_CONTROLLER_MANAGER}-cloudcontrollermanagerroleid-nsg
+      name: ${MI_CLOUD_CONTROLLER_MANAGER}-cloudcontrollermanagerroleid-nsg-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -182,7 +182,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-readerroleid-cloudcontrollermanagermi
+      name: ${MI_SERVICE}-readerroleid-cloudcontrollermanagermi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -202,7 +202,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_INGRESS}-ingressoperatorroleid-subnet
+      name: ${MI_INGRESS}-ingressoperatorroleid-subnet-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -222,7 +222,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-readerroleid-ingressmi
+      name: ${MI_SERVICE}-readerroleid-ingressmi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -242,7 +242,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-readerroleid-diskcsidrivermi
+      name: ${MI_SERVICE}-readerroleid-diskcsidrivermi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -262,7 +262,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_FILE_CSI_DRIVER}-filestorageoperatorroleid-subnet
+      name: ${MI_FILE_CSI_DRIVER}-filestorageoperatorroleid-subnet-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -282,7 +282,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_FILE_CSI_DRIVER}-filestorageoperatorroleid-nsg
+      name: ${MI_FILE_CSI_DRIVER}-filestorageoperatorroleid-nsg-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -302,7 +302,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-readerroleid-filecsidrivermi
+      name: ${MI_SERVICE}-readerroleid-filecsidrivermi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -322,7 +322,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-readerroleid-imageregistrymi
+      name: ${MI_SERVICE}-readerroleid-imageregistrymi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -342,7 +342,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_CLOUD_NETWORK_CONFIG}-networkoperatorroleid-subnet
+      name: ${MI_CLOUD_NETWORK_CONFIG}-networkoperatorroleid-subnet-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -362,7 +362,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_CLOUD_NETWORK_CONFIG}-networkoperatorroleid-vnet
+      name: ${MI_CLOUD_NETWORK_CONFIG}-networkoperatorroleid-vnet-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -382,7 +382,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-readerroleid-cloudnetworkconfigmi
+      name: ${MI_SERVICE}-readerroleid-cloudnetworkconfigmi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -402,7 +402,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-federatedcredentialsroleid-dpdiskcsidrivermi
+      name: ${MI_SERVICE}-federatedcredentialsroleid-dpdiskcsidrivermi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -422,7 +422,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-federatedcredentialsroleid-dpfilecsidrivermi
+      name: ${MI_SERVICE}-federatedcredentialsroleid-dpfilecsidrivermi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -442,7 +442,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_DP_FILE_CSI_DRIVER}-filestorageoperatorroleid-subnet
+      name: ${MI_DP_FILE_CSI_DRIVER}-filestorageoperatorroleid-subnet-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -462,7 +462,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_DP_FILE_CSI_DRIVER}-filestorageoperatorroleid-nsg
+      name: ${MI_DP_FILE_CSI_DRIVER}-filestorageoperatorroleid-nsg-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -482,7 +482,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-federatedcredentialsroleid-dpimageregistrymi
+      name: ${MI_SERVICE}-federatedcredentialsroleid-dpimageregistrymi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -502,7 +502,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-vnet
+      name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-vnet-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -522,7 +522,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-subnet
+      name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-subnet-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -542,7 +542,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-intsubnet
+      name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-intsubnet-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
@@ -562,7 +562,7 @@
   - apiVersion: authorization.azure.com/v1api20220401
     kind: RoleAssignment
     metadata:
-      name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-nsg
+      name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-nsg-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete

--- a/scripts/aro-hcp/gen.sh
+++ b/scripts/aro-hcp/gen.sh
@@ -137,6 +137,12 @@ if [ -n "$MSI_RESOURCEGROUPNAME" ]; then
     export MI_DP_FILE_CSI_DRIVER="dp-file-csi-driver"
     export MI_DP_IMAGE_REGISTRY="dp-image-registry"
     export MI_SERVICE="service"
+    MSI_RG_TAIL="${MSI_RESOURCEGROUPNAME##*-}"
+    if [[ "$MSI_RG_TAIL" =~ ^[0-9]+$ ]]; then
+        export MSI_SUFFIX="$MSI_RG_TAIL"
+    else
+        export MSI_SUFFIX="$NAME_PREFIX"
+    fi
 else
     export MSI_RESOURCEGROUPNAME="$RESOURCEGROUPNAME"
     export MI_CLUSTER_API_AZURE="${USER}-${CS_CLUSTER_NAME}-cp-cluster-api-azure-${OPERATORS_UAMIS_SUFFIX}"
@@ -152,6 +158,7 @@ else
     export MI_DP_FILE_CSI_DRIVER="${USER}-${CS_CLUSTER_NAME}-dp-file-csi-driver-${OPERATORS_UAMIS_SUFFIX}"
     export MI_DP_IMAGE_REGISTRY="${USER}-${CS_CLUSTER_NAME}-dp-image-registry-${OPERATORS_UAMIS_SUFFIX}"
     export MI_SERVICE="${USER}-${CS_CLUSTER_NAME}-service-managed-identity-${OPERATORS_UAMIS_SUFFIX}"
+    export MSI_SUFFIX="0"
 fi
 
 export VNET="$NAME_PREFIX-vnet-$OPERATORS_UAMIS_SUFFIX"

--- a/scripts/aro-hcp/is-template-roleassignments-ref.yaml
+++ b/scripts/aro-hcp/is-template-roleassignments-ref.yaml
@@ -2,7 +2,7 @@
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_CLUSTER_API_AZURE}-hcpclusterapiproviderroleid-subnet
+  name: ${MI_CLUSTER_API_AZURE}-hcpclusterapiproviderroleid-subnet-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -22,7 +22,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-readerroleid-clusterapiazuremi
+  name: ${MI_SERVICE}-readerroleid-clusterapiazuremi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -42,7 +42,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_KMS}-keyvaultcryptouserroleid-keyvault
+  name: ${MI_KMS}-keyvaultcryptouserroleid-keyvault-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -62,7 +62,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-readerroleid-kmsmi
+  name: ${MI_SERVICE}-readerroleid-kmsmi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -82,7 +82,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_CONTROL_PLANE}-hcpcontrolplaneoperatorroleid-vnet
+  name: ${MI_CONTROL_PLANE}-hcpcontrolplaneoperatorroleid-vnet-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -102,7 +102,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_CONTROL_PLANE}-hcpcontrolplaneoperatorroleid-nsg
+  name: ${MI_CONTROL_PLANE}-hcpcontrolplaneoperatorroleid-nsg-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -122,7 +122,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-readerroleid-controlplanemi
+  name: ${MI_SERVICE}-readerroleid-controlplanemi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -142,7 +142,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_CLOUD_CONTROLLER_MANAGER}-cloudcontrollermanagerroleid-subnet
+  name: ${MI_CLOUD_CONTROLLER_MANAGER}-cloudcontrollermanagerroleid-subnet-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -162,7 +162,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_CLOUD_CONTROLLER_MANAGER}-cloudcontrollermanagerroleid-nsg
+  name: ${MI_CLOUD_CONTROLLER_MANAGER}-cloudcontrollermanagerroleid-nsg-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -182,7 +182,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-readerroleid-cloudcontrollermanagermi
+  name: ${MI_SERVICE}-readerroleid-cloudcontrollermanagermi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -202,7 +202,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_INGRESS}-ingressoperatorroleid-subnet
+  name: ${MI_INGRESS}-ingressoperatorroleid-subnet-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -222,7 +222,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-readerroleid-ingressmi
+  name: ${MI_SERVICE}-readerroleid-ingressmi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -242,7 +242,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-readerroleid-diskcsidrivermi
+  name: ${MI_SERVICE}-readerroleid-diskcsidrivermi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -262,7 +262,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_FILE_CSI_DRIVER}-filestorageoperatorroleid-subnet
+  name: ${MI_FILE_CSI_DRIVER}-filestorageoperatorroleid-subnet-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -282,7 +282,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_FILE_CSI_DRIVER}-filestorageoperatorroleid-nsg
+  name: ${MI_FILE_CSI_DRIVER}-filestorageoperatorroleid-nsg-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -302,7 +302,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-readerroleid-filecsidrivermi
+  name: ${MI_SERVICE}-readerroleid-filecsidrivermi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -322,7 +322,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-readerroleid-imageregistrymi
+  name: ${MI_SERVICE}-readerroleid-imageregistrymi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -342,7 +342,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_CLOUD_NETWORK_CONFIG}-networkoperatorroleid-subnet
+  name: ${MI_CLOUD_NETWORK_CONFIG}-networkoperatorroleid-subnet-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -362,7 +362,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_CLOUD_NETWORK_CONFIG}-networkoperatorroleid-vnet
+  name: ${MI_CLOUD_NETWORK_CONFIG}-networkoperatorroleid-vnet-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -382,7 +382,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-readerroleid-cloudnetworkconfigmi
+  name: ${MI_SERVICE}-readerroleid-cloudnetworkconfigmi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -402,7 +402,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-federatedcredentialsroleid-dpdiskcsidrivermi
+  name: ${MI_SERVICE}-federatedcredentialsroleid-dpdiskcsidrivermi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -422,7 +422,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-federatedcredentialsroleid-dpfilecsidrivermi
+  name: ${MI_SERVICE}-federatedcredentialsroleid-dpfilecsidrivermi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -442,7 +442,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_DP_FILE_CSI_DRIVER}-filestorageoperatorroleid-subnet
+  name: ${MI_DP_FILE_CSI_DRIVER}-filestorageoperatorroleid-subnet-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -462,7 +462,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_DP_FILE_CSI_DRIVER}-filestorageoperatorroleid-nsg
+  name: ${MI_DP_FILE_CSI_DRIVER}-filestorageoperatorroleid-nsg-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -482,7 +482,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-federatedcredentialsroleid-dpimageregistrymi
+  name: ${MI_SERVICE}-federatedcredentialsroleid-dpimageregistrymi-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -502,7 +502,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-vnet
+  name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-vnet-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -522,7 +522,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-subnet
+  name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-subnet-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
@@ -542,7 +542,7 @@ spec:
 apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
-  name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-nsg
+  name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-nsg-${MSI_SUFFIX}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}


### PR DESCRIPTION
## Summary
- Appends `-${MSI_SUFFIX}` to all RoleAssignment `metadata.name` fields in the `-ref` templates (Boskos MSI pool mode)
- `MSI_SUFFIX` is the numeric tail of `MSI_RESOURCEGROUPNAME` (e.g. `166` from `aro-hcp-test-msi-containers-dev-166`), with `NAME_PREFIX` fallback if the tail is not numeric
- Prevents `RoleAssignmentUpdateNotPermitted` errors caused by Azure GUID collisions across different Boskos MSI resource groups

## Problem
ASO generates deterministic UUIDv5 GUIDs from K8s resource names. With bare MI_ names (e.g. `service`, `kms`) the role assignment GUIDs are identical across CI runs. Combined with `detach-on-delete` reconcile policy, stale assignments from a previous run on one Boskos MSI resource group (e.g. `dev-272`) block new runs on different MSI resource groups (`dev-166`, `dev-177`) with `RoleAssignmentUpdateNotPermitted`.

## Solution
Make role assignment K8s names unique per Boskos pool by appending the pool's numeric suffix. This:
- Prevents GUID collisions across different pools
- Remains idempotent for consecutive runs on the same pool (no stale assignment accumulation)
- Falls back to `NAME_PREFIX` (unique per run) if the MSI RG name doesn't end with a number

## Test plan
- [ ] Verify dev CI test passes with different Boskos MSI pool leases
- [ ] Verify production CI test still passes (uses separate MSI RG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)