### PR TITLE
set the missing label to resolve fips testing problem

### DIFF
--- a/mce-capi-webhook-config/Dockerfile
+++ b/mce-capi-webhook-config/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=1 GO111MODULE=on GOEXPERIMENT=strictfipsruntime go build -a -o /
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-LABEL com.redhat.component="" \
+LABEL com.redhat.component="mce-capi-webhook-config" \
       url="mce-capi-webhook-config/Dockerfile" \
       description="Auto-labeling CAPI resources based on openshift and hypershift namespaces" \
       io.k8s.description="Auto-labeling CAPI resources based on namespaces" \


### PR DESCRIPTION
We cannot deliver z stream releases that include this component until the FIPS validation is passing.  I don't think this is a FIPS error -- I think their validation script just requires this label to be set.  Currently blocking our 2.9.3 z stream so the fix needs to be cherry picked.