### PR TITLE
Bump setup-envtest to release-0.22

### DIFF
--- a/mce-capi-webhook-config/Makefile
+++ b/mce-capi-webhook-config/Makefile
@@ -28,7 +28,7 @@ build: mce-capi-webhook-config
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
 
 .PHONY: test
 test: envtest ## Run tests.


### PR DESCRIPTION
## Summary
- Bumps `setup-envtest` from `release-0.17` to `release-0.22` to fix GCS `401 Unauthorized` error when downloading envtest binaries
- This aligns with the version already used on `main`
- Fixes CI test failures in #714 and any other PRs targeting `backplane-2.11`

## Test plan
- [ ] CI `build` check passes (envtest binaries download successfully)