### PR TITLE
Constrain k8s.io and controller-runtime versions for Mintmaker

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,33 @@
                 "indirect"
             ],
             "enabled": false
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchPackagePatterns": [
+                "^k8s.io/"
+            ],
+            "allowedVersions": "<0.35.0"
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchPackageNames": [
+                "sigs.k8s.io/controller-runtime"
+            ],
+            "allowedVersions": "<0.20.0"
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchPackageNames": [
+                "sigs.k8s.io/cluster-api"
+            ],
+            "allowedVersions": "<1.10.0"
         }
     ],
     "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
## Summary
- Adds `allowedVersions` constraints to `renovate.json` to prevent Mintmaker from proposing incompatible dependency bumps
- Caps `k8s.io/*` at `<0.35.0` (compatible with `controller-runtime@v0.19.x`)
- Caps `sigs.k8s.io/controller-runtime` at `<0.20.0`
- Caps `sigs.k8s.io/cluster-api` at `<1.10.0`
- Fixes the build failure in #709 where `k8s.io/*@v0.36` introduced a `HasSyncedChecker` interface method that `controller-runtime@v0.19.4` doesn't implement

## Test plan
- [ ] Verify Mintmaker no longer proposes `k8s.io/*@v0.36` updates on this branch
- [ ] PR #709 should be superseded — close it after this merges