### PR TITLE
ARO-HCP: Fix shared MSI lifecycle for Boskos pool mode

### DIFF
--- a/scripts/aro-hcp/aro-template-identities-ref.yaml
+++ b/scripts/aro-hcp/aro-template-identities-ref.yaml
@@ -1,14 +1,3 @@
-  # ASO reference to the pre-existing MSI resource group.
-  # detach-on-delete ensures ASO adopts but never deletes the Azure resource.
-  - apiVersion: resources.azure.com/v1api20200601
-    kind: ResourceGroup
-    metadata:
-      name: ${MSI_RESOURCEGROUPNAME}
-      namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
-    spec:
-      location: ${REGION}
   - apiVersion: managedidentity.azure.com/v1api20230131
     kind: UserAssignedIdentity
     metadata:
@@ -17,9 +6,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -36,9 +25,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -55,9 +44,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -74,9 +63,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -93,9 +82,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -112,9 +101,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -131,9 +120,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -150,9 +139,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -169,9 +158,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -188,9 +177,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -207,9 +196,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -226,9 +215,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:
@@ -245,9 +234,9 @@
       annotations:
         serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
-        name: ${MSI_RESOURCEGROUPNAME}
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
       operatorSpec:
         configMaps:
           principalId:

--- a/scripts/aro-hcp/aro-template-identities.yaml
+++ b/scripts/aro-hcp/aro-template-identities.yaml
@@ -7,7 +7,7 @@
       name: ${MI_CONTROL_PLANE}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -27,7 +27,7 @@
       name: ${MI_CLUSTER_API_AZURE}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -47,7 +47,7 @@
       name: ${MI_CLOUD_CONTROLLER_MANAGER}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -67,7 +67,7 @@
       name: ${MI_INGRESS}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -87,7 +87,7 @@
       name: ${MI_DISK_CSI_DRIVER}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -107,7 +107,7 @@
       name: ${MI_FILE_CSI_DRIVER}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -127,7 +127,7 @@
       name: ${MI_IMAGE_REGISTRY}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -147,7 +147,7 @@
       name: ${MI_CLOUD_NETWORK_CONFIG}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -167,7 +167,7 @@
       name: ${MI_KMS}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -187,7 +187,7 @@
       name: ${MI_DP_DISK_CSI_DRIVER}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -207,7 +207,7 @@
       name: ${MI_DP_IMAGE_REGISTRY}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -227,7 +227,7 @@
       name: ${MI_DP_FILE_CSI_DRIVER}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:
@@ -247,7 +247,7 @@
       name: ${MI_SERVICE}
       namespace: ${NAMESPACE}
     spec:
-      location: ${REGION}
+      location: ${MSI_REGION}
       owner:
         name: ${RESOURCEGROUPNAME}
       operatorSpec:

--- a/scripts/aro-hcp/aro-template-roleassignments-ref.yaml
+++ b/scripts/aro-hcp/aro-template-roleassignments-ref.yaml
@@ -24,13 +24,9 @@
     metadata:
       name: ${MI_SERVICE}-readerroleid-clusterapiazuremi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_CLUSTER_API_AZURE}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_CLUSTER_API_AZURE}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId
@@ -64,13 +60,9 @@
     metadata:
       name: ${MI_SERVICE}-readerroleid-kmsmi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_KMS}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_KMS}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId
@@ -124,13 +116,9 @@
     metadata:
       name: ${MI_SERVICE}-readerroleid-controlplanemi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_CONTROL_PLANE}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_CONTROL_PLANE}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId
@@ -184,13 +172,9 @@
     metadata:
       name: ${MI_SERVICE}-readerroleid-cloudcontrollermanagermi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_CLOUD_CONTROLLER_MANAGER}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_CLOUD_CONTROLLER_MANAGER}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId
@@ -224,13 +208,9 @@
     metadata:
       name: ${MI_SERVICE}-readerroleid-ingressmi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_INGRESS}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_INGRESS}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId
@@ -244,13 +224,9 @@
     metadata:
       name: ${MI_SERVICE}-readerroleid-diskcsidrivermi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_DISK_CSI_DRIVER}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_DISK_CSI_DRIVER}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId
@@ -304,13 +280,9 @@
     metadata:
       name: ${MI_SERVICE}-readerroleid-filecsidrivermi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_FILE_CSI_DRIVER}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_FILE_CSI_DRIVER}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId
@@ -324,13 +296,9 @@
     metadata:
       name: ${MI_SERVICE}-readerroleid-imageregistrymi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_IMAGE_REGISTRY}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_IMAGE_REGISTRY}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId
@@ -384,13 +352,9 @@
     metadata:
       name: ${MI_SERVICE}-readerroleid-cloudnetworkconfigmi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_CLOUD_NETWORK_CONFIG}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_CLOUD_NETWORK_CONFIG}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId
@@ -404,13 +368,9 @@
     metadata:
       name: ${MI_SERVICE}-federatedcredentialsroleid-dpdiskcsidrivermi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_DP_DISK_CSI_DRIVER}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_DP_DISK_CSI_DRIVER}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId
@@ -424,13 +384,9 @@
     metadata:
       name: ${MI_SERVICE}-federatedcredentialsroleid-dpfilecsidrivermi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_DP_FILE_CSI_DRIVER}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_DP_FILE_CSI_DRIVER}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId
@@ -484,13 +440,9 @@
     metadata:
       name: ${MI_SERVICE}-federatedcredentialsroleid-dpimageregistrymi-${MSI_SUFFIX}
       namespace: ${NAMESPACE}
-      annotations:
-        serviceoperator.azure.com/reconcile-policy: detach-on-delete
     spec:
       owner:
-        name: ${MI_DP_IMAGE_REGISTRY}
-        group: managedidentity.azure.com
-        kind: UserAssignedIdentity
+        armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_DP_IMAGE_REGISTRY}
       principalIdFromConfig:
         name: identity-map-${MI_SERVICE}
         key: principalId

--- a/scripts/aro-hcp/aro-template-v1api20240610preview.yaml
+++ b/scripts/aro-hcp/aro-template-v1api20240610preview.yaml
@@ -238,6 +238,13 @@ spec:
       namespace: ${NAMESPACE}
     spec:
       location: ${REGION}
+      tags:
+        createdAt: "${CREATED_AT}"
+        capi-test-user: "${USER}"
+        capi-test-env: "${DEPLOYMENT_ENV}"
+        capi-test-run-id: "${NAME_PREFIX}"
+${SWEEPER_DISABLE}        e2e.aro-hcp-ci.redhat.com: "true"
+${SWEEPER_DISABLE}        deleteAfter.aro-hcp-ci.redhat.com: "${DELETE_AFTER}"
   # Equivalent to:
   # az network vnet create -n "${VNET}" -g "${RESOURCEGROUPNAME}"
   # This YAML creates a virtual network named "${VNET}" in the "${RESOURCEGROUPNAME}" resource group.

--- a/scripts/aro-hcp/aro-template.yaml
+++ b/scripts/aro-hcp/aro-template.yaml
@@ -262,6 +262,13 @@ spec:
       namespace: ${NAMESPACE}
     spec:
       location: ${REGION}
+      tags:
+        createdAt: "${CREATED_AT}"
+        capi-test-user: "${USER}"
+        capi-test-env: "${DEPLOYMENT_ENV}"
+        capi-test-run-id: "${NAME_PREFIX}"
+${SWEEPER_DISABLE}        e2e.aro-hcp-ci.redhat.com: "true"
+${SWEEPER_DISABLE}        deleteAfter.aro-hcp-ci.redhat.com: "${DELETE_AFTER}"
   # Equivalent to:
   # az network vnet create -n "${VNET}" -g "${RESOURCEGROUPNAME}"
   # This YAML creates a virtual network named "${VNET}" in the "${RESOURCEGROUPNAME}" resource group.

--- a/scripts/aro-hcp/gen.sh
+++ b/scripts/aro-hcp/gen.sh
@@ -72,6 +72,7 @@ export RESOURCEGROUPNAME=${RESOURCEGROUPNAME:-"$CS_CLUSTER_NAME-resgroup"}
 export OCP_VERSION=${OCP_VERSION:-4.20}
 export OCP_VERSION_MP=${OCP_VERSION_MP:-$OCP_VERSION.17}
 export REGION=${REGION:-westus3}
+export MSI_REGION=${MSI_REGION:-${REGION}}
 export NODEPOOL_PREFIX="w-${REGION:0:7}"
 export NAME_PREFIX="${NAME_PREFIX:0:14}"
 
@@ -137,11 +138,13 @@ if [ -n "$MSI_RESOURCEGROUPNAME" ]; then
     export MI_DP_FILE_CSI_DRIVER="dp-file-csi-driver"
     export MI_DP_IMAGE_REGISTRY="dp-image-registry"
     export MI_SERVICE="service"
-    MSI_RG_TAIL="${MSI_RESOURCEGROUPNAME##*-}"
-    if [[ "$MSI_RG_TAIL" =~ ^[0-9]+$ ]]; then
-        export MSI_SUFFIX="$MSI_RG_TAIL"
-    else
-        export MSI_SUFFIX="$NAME_PREFIX"
+    if [ -z "${MSI_SUFFIX:-}" ]; then
+        MSI_RG_TAIL="${MSI_RESOURCEGROUPNAME##*-}"
+        if [[ "$MSI_RG_TAIL" =~ ^[0-9]+$ ]]; then
+            export MSI_SUFFIX="$MSI_RG_TAIL"
+        else
+            export MSI_SUFFIX="$NAME_PREFIX"
+        fi
     fi
 else
     export MSI_RESOURCEGROUPNAME="$RESOURCEGROUPNAME"
@@ -186,6 +189,11 @@ export EA_AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
 export EA_DISABLE='#'
 [ "$USE_EA" = true ] && EA_DISABLE=''
 
+export CREATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+export DELETE_AFTER=$(date -u -d "+6 hours" +"%Y-%m-%dT%H:%M:%SZ")
+export SWEEPER_DISABLE='#'
+[ "${ARO_HCP_SWEEPER_TAGS}" = "true" ] && SWEEPER_DISABLE=''
+
 echo ENV=$ENV - AZURE_SUBSCRIPTION_NAME=${AZURE_SUBSCRIPTION_NAME} AZURE_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}, REGION=${REGION}
 echo AZURE_TENANT_ID=${AZURE_TENANT_ID}
 echo AZURE_CLIENT_ID=${AZURE_CLIENT_ID} AZURE_ASO_CLIENT_ID=${AZURE_ASO_CLIENT_ID} 
@@ -225,9 +233,9 @@ if [ -z "$GEN_ASO" ] ; then
         echo appending role assignments to: "$GEN_OUTPUT/aro.yaml"
         envsubst  < $TEMPLATE_FILE_ARO_ROLEASSIGNMENTS >> "$GEN_OUTPUT/aro.yaml"
     else
-        echo appending identity references to: "$GEN_OUTPUT/aro.yaml" "(detach-on-delete, MSI from $MSI_RESOURCEGROUPNAME)"
+        echo appending identity references to: "$GEN_OUTPUT/aro.yaml" "(MSI from $MSI_RESOURCEGROUPNAME)"
         envsubst  < $TEMPLATE_FILE_ARO_IDENTITIES_REF >> "$GEN_OUTPUT/aro.yaml"
-        echo appending role assignment references to: "$GEN_OUTPUT/aro.yaml" "(detach-on-delete)"
+        echo appending role assignment references to: "$GEN_OUTPUT/aro.yaml" "(owner.armId, MSI from $MSI_RESOURCEGROUPNAME)"
         envsubst  < $TEMPLATE_FILE_ARO_ROLEASSIGNMENTS_REF >> "$GEN_OUTPUT/aro.yaml"
     fi
 else
@@ -244,9 +252,9 @@ else
         echo appending role assignments to: "$GEN_OUTPUT/is.yaml"
         envsubst  < $TEMPLATE_FILE_IS_ROLEASSIGNMENTS >> "$GEN_OUTPUT/is.yaml"
     else
-        echo appending identity references to: "$GEN_OUTPUT/is.yaml" "(detach-on-delete, MSI from $MSI_RESOURCEGROUPNAME)"
+        echo appending identity references to: "$GEN_OUTPUT/is.yaml" "(MSI from $MSI_RESOURCEGROUPNAME)"
         envsubst  < $TEMPLATE_FILE_IS_IDENTITIES_REF >> "$GEN_OUTPUT/is.yaml"
-        echo appending role assignment references to: "$GEN_OUTPUT/is.yaml" "(detach-on-delete)"
+        echo appending role assignment references to: "$GEN_OUTPUT/is.yaml" "(owner.armId, MSI from $MSI_RESOURCEGROUPNAME)"
         envsubst  < $TEMPLATE_FILE_IS_ROLEASSIGNMENTS_REF >> "$GEN_OUTPUT/is.yaml"
     fi
 

--- a/scripts/aro-hcp/is-template-identities-ref.yaml
+++ b/scripts/aro-hcp/is-template-identities-ref.yaml
@@ -1,16 +1,4 @@
 ---
-# ASO reference to the pre-existing MSI resource group.
-# detach-on-delete ensures ASO adopts but never deletes the Azure resource.
-apiVersion: resources.azure.com/v1api20200601
-kind: ResourceGroup
-metadata:
-  name: ${MSI_RESOURCEGROUPNAME}
-  namespace: ${NAMESPACE}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
-spec:
-  location: ${REGION}
----
 apiVersion: managedidentity.azure.com/v1api20230131
 kind: UserAssignedIdentity
 metadata:
@@ -19,9 +7,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -39,9 +27,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -59,9 +47,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -79,9 +67,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -99,9 +87,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -119,9 +107,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -139,9 +127,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -159,9 +147,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -179,9 +167,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -199,9 +187,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -219,9 +207,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -239,9 +227,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:
@@ -259,9 +247,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
-    name: ${MSI_RESOURCEGROUPNAME}
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}
   operatorSpec:
     configMaps:
       principalId:

--- a/scripts/aro-hcp/is-template-identities.yaml
+++ b/scripts/aro-hcp/is-template-identities.yaml
@@ -8,7 +8,7 @@ metadata:
   name: ${MI_CONTROL_PLANE}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -29,7 +29,7 @@ metadata:
   name: ${MI_CLUSTER_API_AZURE}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -50,7 +50,7 @@ metadata:
   name: ${MI_CLOUD_CONTROLLER_MANAGER}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -71,7 +71,7 @@ metadata:
   name: ${MI_INGRESS}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -92,7 +92,7 @@ metadata:
   name: ${MI_DISK_CSI_DRIVER}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -113,7 +113,7 @@ metadata:
   name: ${MI_FILE_CSI_DRIVER}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -134,7 +134,7 @@ metadata:
   name: ${MI_IMAGE_REGISTRY}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -155,7 +155,7 @@ metadata:
   name: ${MI_CLOUD_NETWORK_CONFIG}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -176,7 +176,7 @@ metadata:
   name: ${MI_KMS}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -197,7 +197,7 @@ metadata:
   name: ${MI_DP_DISK_CSI_DRIVER}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -218,7 +218,7 @@ metadata:
   name: ${MI_DP_IMAGE_REGISTRY}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -239,7 +239,7 @@ metadata:
   name: ${MI_DP_FILE_CSI_DRIVER}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:
@@ -260,7 +260,7 @@ metadata:
   name: ${MI_SERVICE}
   namespace: ${NAMESPACE}
 spec:
-  location: ${REGION}
+  location: ${MSI_REGION}
   owner:
     name: ${RESOURCEGROUPNAME}
   operatorSpec:

--- a/scripts/aro-hcp/is-template-roleassignments-ref.yaml
+++ b/scripts/aro-hcp/is-template-roleassignments-ref.yaml
@@ -3,9 +3,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_CLUSTER_API_AZURE}-hcpclusterapiproviderroleid-subnet-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${VNET}-${SUBNET}
@@ -23,14 +23,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-readerroleid-clusterapiazuremi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_CLUSTER_API_AZURE}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_CLUSTER_API_AZURE}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -43,9 +39,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_KMS}-keyvaultcryptouserroleid-keyvault-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${KV}
@@ -63,14 +59,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-readerroleid-kmsmi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_KMS}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_KMS}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -83,9 +75,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_CONTROL_PLANE}-hcpcontrolplaneoperatorroleid-vnet-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${VNET}
@@ -103,9 +95,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_CONTROL_PLANE}-hcpcontrolplaneoperatorroleid-nsg-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${NSG}
@@ -123,14 +115,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-readerroleid-controlplanemi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_CONTROL_PLANE}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_CONTROL_PLANE}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -143,9 +131,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_CLOUD_CONTROLLER_MANAGER}-cloudcontrollermanagerroleid-subnet-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${VNET}-${SUBNET}
@@ -163,9 +151,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_CLOUD_CONTROLLER_MANAGER}-cloudcontrollermanagerroleid-nsg-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${NSG}
@@ -183,14 +171,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-readerroleid-cloudcontrollermanagermi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_CLOUD_CONTROLLER_MANAGER}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_CLOUD_CONTROLLER_MANAGER}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -203,9 +187,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_INGRESS}-ingressoperatorroleid-subnet-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${VNET}-${SUBNET}
@@ -223,14 +207,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-readerroleid-ingressmi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_INGRESS}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_INGRESS}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -243,14 +223,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-readerroleid-diskcsidrivermi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_DISK_CSI_DRIVER}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_DISK_CSI_DRIVER}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -263,9 +239,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_FILE_CSI_DRIVER}-filestorageoperatorroleid-subnet-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${VNET}-${SUBNET}
@@ -283,9 +259,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_FILE_CSI_DRIVER}-filestorageoperatorroleid-nsg-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${NSG}
@@ -303,14 +279,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-readerroleid-filecsidrivermi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_FILE_CSI_DRIVER}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_FILE_CSI_DRIVER}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -323,14 +295,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-readerroleid-imageregistrymi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_IMAGE_REGISTRY}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_IMAGE_REGISTRY}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -343,9 +311,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_CLOUD_NETWORK_CONFIG}-networkoperatorroleid-subnet-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${VNET}-${SUBNET}
@@ -363,9 +331,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_CLOUD_NETWORK_CONFIG}-networkoperatorroleid-vnet-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${VNET}
@@ -383,14 +351,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-readerroleid-cloudnetworkconfigmi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_CLOUD_NETWORK_CONFIG}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_CLOUD_NETWORK_CONFIG}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -403,14 +367,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-federatedcredentialsroleid-dpdiskcsidrivermi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_DP_DISK_CSI_DRIVER}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_DP_DISK_CSI_DRIVER}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -423,14 +383,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-federatedcredentialsroleid-dpfilecsidrivermi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_DP_FILE_CSI_DRIVER}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_DP_FILE_CSI_DRIVER}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -443,9 +399,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_DP_FILE_CSI_DRIVER}-filestorageoperatorroleid-subnet-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${VNET}-${SUBNET}
@@ -463,9 +419,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_DP_FILE_CSI_DRIVER}-filestorageoperatorroleid-nsg-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${NSG}
@@ -483,14 +439,10 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-federatedcredentialsroleid-dpimageregistrymi-${MSI_SUFFIX}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${MI_DP_IMAGE_REGISTRY}
-    group: managedidentity.azure.com
-    kind: UserAssignedIdentity
+    armId: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${MSI_RESOURCEGROUPNAME}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${MI_DP_IMAGE_REGISTRY}
   principalIdFromConfig:
     name: identity-map-${MI_SERVICE}
     key: principalId
@@ -503,9 +455,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-vnet-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${VNET}
@@ -523,9 +475,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-subnet-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${VNET}-${SUBNET}
@@ -543,9 +495,9 @@ apiVersion: authorization.azure.com/v1api20220401
 kind: RoleAssignment
 metadata:
   name: ${MI_SERVICE}-hcpservicemanagedidentityroleid-nsg-${MSI_SUFFIX}
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
-  namespace: ${NAMESPACE}
 spec:
   owner:
     name: ${NSG}

--- a/scripts/deploy-charts.sh
+++ b/scripts/deploy-charts.sh
@@ -80,7 +80,7 @@ function set_namespace_and_t {
 CHARTS=$(echo cluster-api $*|tr ' ' '\n'|sort -u|tr '\n' ' ')
 
 if [ "$ARO_NULL_PROVISIONING" = "true" ] ; then
-    CHARTS=$(echo aro-mockup-proxy $CHARTS|tr ' ' '\n'|sort -u|tr '\n' ' ')
+    CHARTS="$CHARTS aro-mockup-proxy"
 fi
 
 if [ "$DO_DEPLOY" = true ] ; then
@@ -96,7 +96,7 @@ if [ "$DO_DEPLOY" = true ] ; then
         echo "      NAMESPACE: $NAMESPACE"
         kubectl $KUBE_CONTEXT get namespace "$NAMESPACE" >/dev/null 2>&1 || kubectl $KUBE_CONTEXT create namespace "$NAMESPACE" 
         # Create prerequisites for aro-mockup-proxy
-        if [ "$PROJECT" = "aro-mockup-proxy" ] ; then
+        if [ "$PROJECT" = "aro-mockup-proxy" ] && [ -z "${DEV_ENDPOINT:-}" ] ; then
             KUBECONFIG_FILE=${MOCK_KUBECONFIG_FILE:-"${SCRIPT_DIR}/../aro-mockup-proxy/workload-kubeconfig.yaml"}
             if [ -f "$KUBECONFIG_FILE" ] ; then
                 echo "  Creating mockup-proxy-kubeconfig secret from $KUBECONFIG_FILE"
@@ -110,7 +110,7 @@ if [ "$DO_DEPLOY" = true ] ; then
         # Pass DEV_ENDPOINT to aro-mockup-proxy chart when set
         DEV_ENDPOINT_ARG=""
         if [ "$PROJECT" = "aro-mockup-proxy" -a -n "$DEV_ENDPOINT" ] ; then
-            DEV_ENDPOINT_ARG="--set config.devEndpoint=$DEV_ENDPOINT"
+            DEV_ENDPOINT_ARG="--set config.devEndpoint=$DEV_ENDPOINT --set kubeconfig.secretName="
             echo "  DEV_ENDPOINT: $DEV_ENDPOINT (hcpOpenShiftCluster requests will be forwarded)"
         fi
         echo "      HELM ARGS: --set Release.Namespace=$NAMESPACE" ${helm_add_args_a[$T]} $DEV_ENDPOINT_ARG
@@ -120,6 +120,18 @@ if [ "$DO_DEPLOY" = true ] ; then
             --set imagePullSecret=${IMAGE_PULL_SECRET_B64} \
             --set "Release.Namespace=$NAMESPACE" \
             ${helm_add_args_a[$T]} $DEV_ENDPOINT_ARG|kubectl $KUBE_CONTEXT -n "$NAMESPACE" apply -f - --server-side --force-conflicts
+        # Wait for cert-manager to issue the TLS certificate before proceeding
+        if [ "$PROJECT" = "aro-mockup-proxy" ] && [ -z "${DEV_ENDPOINT:-}" ] ; then
+            echo "  Waiting for TLS secret aro-mockup-proxy-tls to be created by cert-manager..."
+            for i in $(seq 1 60); do
+                if kubectl $KUBE_CONTEXT -n "$NAMESPACE" get secret aro-mockup-proxy-tls >/dev/null 2>&1; then
+                    echo "  TLS secret ready"
+                    break
+                fi
+                [ $i -eq 60 ] && echo "  WARNING: TLS secret not ready after 60s, continuing anyway"
+                sleep 1
+            done
+        fi
         echo
     done
 fi


### PR DESCRIPTION
## Summary

- Use `owner.armId` for identity-scoped RoleAssignments in `-ref` templates to avoid ASO finalizer race conditions during concurrent deletion. Remove `detach-on-delete` from these RAs so they are explicitly cleaned up by the post-test CI step.
- Add `detach-on-delete` to network/keyvault-scoped RoleAssignments (VNet, Subnet, NSG, KeyVault) in `-ref` templates — Azure cleans them up when the test RG is deleted.
- Remove `ResourceGroup` CR from identity-ref files (not created by us); replace `owner.name` with `owner.armId` on `UserAssignedIdentity` CRs.
- Honor pre-set `MSI_SUFFIX` in `gen.sh` (CI slot-manager sets it).
- Introduce `MSI_REGION` for identity locations, separate from `REGION`.
- Add sweeper tags to workload cluster ResourceGroup for ARO-HCP sweeper cleanup (`ARO_HCP_SWEEPER_TAGS=true`).
- Deploy aro-mockup-proxy after CAPZ chart (cert-manager issuer dependency).
- Skip kubeconfig secret mount and wait for TLS cert in dev mode (`DEV_ENDPOINT`).

## Test plan

- [ ] Verify CI e2e tests pass with Boskos MSI pool mode (shared MSI)
- [ ] Verify CI e2e tests pass with same-RG MSI mode (non-shared)
- [ ] Verify dev mode with `DEV_ENDPOINT` set
- [ ] Verify sweeper tags appear on workload cluster RG when `ARO_HCP_SWEEPER_TAGS=true`

Ref: ARO-27593, ARO-28192