### PR TITLE
fix: disable AutoControllerIdentityCreator for CAPA

### DIFF
--- a/charts/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
+++ b/charts/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
       - args:
         - --leader-elect
-        - --feature-gates=EKS=true,EKSEnableIAM=true,EKSAllowAddRoles=true,EKSFargate=true,MachinePool=true,MachinePoolMachines=true,EventBridgeInstanceState=false,AutoControllerIdentityCreator=true,BootstrapFormatIgnition=false,ExternalResourceGC=true,AlternativeGCStrategy=false,TagUnmanagedNetworkResources=true,ROSA=true
+        - --feature-gates=EKS=true,EKSEnableIAM=true,EKSAllowAddRoles=true,EKSFargate=true,MachinePool=true,MachinePoolMachines=true,EventBridgeInstanceState=false,AutoControllerIdentityCreator=false,BootstrapFormatIgnition=false,ExternalResourceGC=true,AlternativeGCStrategy=false,TagUnmanagedNetworkResources=true,ROSA=true
         - --v=0
         - --diagnostics-address=:8443
         - --insecure-diagnostics=false

--- a/config/cluster-api-provider-aws/env
+++ b/config/cluster-api-provider-aws/env
@@ -3,3 +3,4 @@ export CAPA_EKS_ADD_ROLES=true
 export EXP_EKS_FARGATE=true
 export EXP_MACHINE_POOL=true
 export EXP_ROSA=true
+export AUTO_CONTROLLER_IDENTITY_CREATOR=false


### PR DESCRIPTION
## Summary
  - Disable `AutoControllerIdentityCreator` feature gate in the CAPA controller deployment
  - In ROSAENG-8318 we removed unused CAPA CRDs (including `AWSCluster`) to avoid conflicts with OCP 5.0 which will include CAPI/CAPA natively. However, the `AutoControllerIdentityCreator` controller watches `AWSCluster` via `For(&infrav1.AWSCluster{})` — with the CRD removed, the cache sync fails and crashes the entire CAPA controller
  manager, including all ROSA controllers
  - `--disable-controllers=unmanaged` does not cover this controller; it's gated separately by `AutoControllerIdentityCreator`
  - ROSA doesn't need this controller — it auto-creates `AWSClusterControllerIdentity` only when `AWSCluster` events appear, but ROSA uses `ROSACluster` and creates identities manually. The feature was originally meant to be temporary (introduced to facilitate multi-tenancy migration, intended to be disabled after v1alpha4, but never was)
  - This is safe because our deployments use explicit identity references (`AWSClusterRoleIdentity` `AWSClusterControllerIdentity`) which are both still present and referenced by `ROSAControlPlane`