### PR TITLE
fix: isolate env variables between chart build variants

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -174,9 +174,11 @@ build_for_config() {
 mkdir -p "${WKDIR}"
 
 # Execute build function with config type (default to "config" for backward compatibility)
-build_for_config "config"
+# Each call runs in a subshell so exported env variables (from sourcing the env file)
+# don't leak between config variants.
+(build_for_config "config")
 for suffix in k8s kind; do
   if [ -d $PROJECT_ROOT/config-$suffix/$PROJECT ]; then
-       build_for_config "config-$suffix"
+       (build_for_config "config-$suffix")
   fi
 done


### PR DESCRIPTION
## Summary
  - Run each `build_for_config` call in a subshell so exported env variables from one config variant don't leak into the next
  - Currently `build.sh` sources `config/<provider>/env` then `config-kind/<provider>/env` in the same shell. If the kind env file doesn't set a variable, it inherits the value from the OCP build. For example, `AUTO_CONTROLLER_IDENTITY_CREATOR=false` set in the OCP env was leaking into the kind chart build, which should default to `true`
  - The fix wraps each `build_for_config` call in parentheses `()`, which creates a subshell — env changes die when it exits
  - Tested locally with `make build-docker`: OCP chart correctly gets `AutoControllerIdentityCreator=false`, kind chart correctly gets `AutoControllerIdentityCreator=true