### PR TITLE
[backplane-2.17] MGMT-24787: Pin CAPM3 CRD storage version to prevent CVO conflict

### DIFF
--- a/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3clusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3clusters.infrastructure.cluster.x-k8s.io.yaml
@@ -302,7 +302,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -597,6 +597,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}

--- a/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3clustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3clustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -115,7 +115,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
   - name: v1beta2
     schema:
       openAPIV3Schema:
@@ -216,4 +216,4 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false

--- a/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3dataclaims.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3dataclaims.infrastructure.cluster.x-k8s.io.yaml
@@ -166,7 +166,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -298,6 +298,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}

--- a/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3datas.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3datas.infrastructure.cluster.x-k8s.io.yaml
@@ -211,7 +211,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -387,6 +387,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}

--- a/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3datatemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3datatemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -1333,7 +1333,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -2632,6 +2632,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}

--- a/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3machines.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3machines.infrastructure.cluster.x-k8s.io.yaml
@@ -571,7 +571,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -1124,6 +1124,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}

--- a/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3machinetemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3machinetemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -280,7 +280,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources: {}
   - additionalPrinterColumns:
     - description: Time duration since creation of Metal3MachineTemplate
@@ -525,5 +525,5 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources: {}

--- a/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3remediations.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3remediations.infrastructure.cluster.x-k8s.io.yaml
@@ -116,7 +116,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -201,6 +201,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}

--- a/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3remediationtemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/charts/cluster-api-provider-metal3/crds/apiextensions.k8s.io_v1_customresourcedefinition_metal3remediationtemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -121,7 +121,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v1beta2
@@ -208,6 +208,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}

--- a/config/cluster-api-provider-metal3/kustomization.yaml
+++ b/config/cluster-api-provider-metal3/kustomization.yaml
@@ -92,6 +92,121 @@ patches:
       - op: add
         path: /metadata/annotations/service.beta.openshift.io~1serving-cert-secret-name
         value: ipam-webhook-service-cert
+  # Pin CAPM3 CRDs to v1beta1 as storage version (MGMT-24787).
+  # On OCP clusters, CVO and the cluster-capi-operator deploy some of these CRDs with
+  # v1beta1 as storage. If MCE sets v1beta2 as storage, Kubernetes records it in
+  # status.storedVersions and CVO can never revert to v1beta1-only, causing a
+  # reconciliation failure that blocks OCP upgrades.
+  # TODO: Remove when openshift/cluster-api-provider-metal3 removes
+  # openshift/patches/crd-storage-version.yaml (signals v1beta2 is safe as storage).
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: metal3clusters.infrastructure.cluster.x-k8s.io
+    patch: |-
+      - op: replace
+        path: /spec/versions/0/storage
+        value: true
+      - op: replace
+        path: /spec/versions/1/storage
+        value: false
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: metal3clustertemplates.infrastructure.cluster.x-k8s.io
+    patch: |-
+      - op: replace
+        path: /spec/versions/0/storage
+        value: true
+      - op: replace
+        path: /spec/versions/1/storage
+        value: false
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: metal3machines.infrastructure.cluster.x-k8s.io
+    patch: |-
+      - op: replace
+        path: /spec/versions/0/storage
+        value: true
+      - op: replace
+        path: /spec/versions/1/storage
+        value: false
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: metal3machinetemplates.infrastructure.cluster.x-k8s.io
+    patch: |-
+      - op: replace
+        path: /spec/versions/0/storage
+        value: true
+      - op: replace
+        path: /spec/versions/1/storage
+        value: false
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: metal3datas.infrastructure.cluster.x-k8s.io
+    patch: |-
+      - op: replace
+        path: /spec/versions/0/storage
+        value: true
+      - op: replace
+        path: /spec/versions/1/storage
+        value: false
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: metal3dataclaims.infrastructure.cluster.x-k8s.io
+    patch: |-
+      - op: replace
+        path: /spec/versions/0/storage
+        value: true
+      - op: replace
+        path: /spec/versions/1/storage
+        value: false
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: metal3datatemplates.infrastructure.cluster.x-k8s.io
+    patch: |-
+      - op: replace
+        path: /spec/versions/0/storage
+        value: true
+      - op: replace
+        path: /spec/versions/1/storage
+        value: false
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: metal3remediations.infrastructure.cluster.x-k8s.io
+    patch: |-
+      - op: replace
+        path: /spec/versions/0/storage
+        value: true
+      - op: replace
+        path: /spec/versions/1/storage
+        value: false
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: metal3remediationtemplates.infrastructure.cluster.x-k8s.io
+    patch: |-
+      - op: replace
+        path: /spec/versions/0/storage
+        value: true
+      - op: replace
+        path: /spec/versions/1/storage
+        value: false
   # Replace Deployment with default values & helm chart value
   - target:
       version: v1


### PR DESCRIPTION
## Summary

Apply the `crd-storage-version.yaml` patch from `openshift/cluster-api-provider-metal3` to all 9 CAPM3 CRDs in the MCE chart build, pinning v1beta1 as the storage version

The CRD conflict was specifically observed in the [4.22 -> 5.0 upgrade path](https://redhat.atlassian.net/browse/MGMT-24787). TBD whether we will need this fix applied to other branches as well.

## Problem

When MCE's CAPM3 chart is deployed on an OCP cluster, it ships CRDs with v1beta2 as the storage version. CVO deploys the same remediation CRDs with v1beta1 only. Once Kubernetes records v1beta2 in `status.storedVersions`, CVO cannot revert to its v1beta1-only definition — the API server rejects the update, and CVO enters a permanent `Failing=True` reconciliation loop that blocks OCP upgrades.

## Fix

The `openshift/cluster-api-provider-metal3` repo already maintains a patch (`openshift/patches/crd-storage-version.yaml`) that pins v1beta1 as storage for the cluster-capi-operator delivery path. This PR references that same patch file from our kustomization so:

- Both API versions (v1beta1 and v1beta2) remain served — the conversion webhook still works
- Only the etcd serialization format changes, which is transparent to clients
- Patch content is owned by CAPM3 upstream — updates (e.g. for v1beta3) are inherited automatically
- If CAPM3 removes the patch (signaling v1beta2 is safe as storage), our build fails loudly rather than silently diverging