### PR TITLE
MGMT-24843: Enable BMH-based IPCLaim names for CAPM3

### DIFF
--- a/charts/cluster-api-provider-metal3-k8s/templates/apps_v1_deployment_mce-capm3-controller-manager.yaml
+++ b/charts/cluster-api-provider-metal3-k8s/templates/apps_v1_deployment_mce-capm3-controller-manager.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - args:
         - --webhook-port=9443
-        - --enableBMHNameBasedPreallocation=false
+        - --enableBMHNameBasedPreallocation=true
         - --diagnostics-address=:8443
         - --insecure-diagnostics=false
         - --tls-min-version=VersionTLS13

--- a/charts/cluster-api-provider-metal3/templates/apps_v1_deployment_mce-capm3-controller-manager.yaml
+++ b/charts/cluster-api-provider-metal3/templates/apps_v1_deployment_mce-capm3-controller-manager.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - args:
         - --webhook-port=9443
-        - --enableBMHNameBasedPreallocation=false
+        - --enableBMHNameBasedPreallocation=true
         - --diagnostics-address=:8443
         - --insecure-diagnostics=false
         - --tls-min-version=VersionTLS13

--- a/config-k8s/cluster-api-provider-metal3/kustomization.yaml
+++ b/config-k8s/cluster-api-provider-metal3/kustomization.yaml
@@ -131,7 +131,7 @@ patches:
         value: '{{ .Values.manager.image.url }}:{{ .Values.manager.image.tag }}'
       - op: replace
         path: /spec/template/spec/containers/0/args/1
-        value: --enableBMHNameBasedPreallocation=false
+        value: --enableBMHNameBasedPreallocation=true
       - op: replace
         path: /spec/template/spec/containers/0/args/2
         value: --diagnostics-address=:8443

--- a/config/cluster-api-provider-metal3/kustomization.yaml
+++ b/config/cluster-api-provider-metal3/kustomization.yaml
@@ -103,7 +103,7 @@ patches:
         value: '{{ .Values.manager.image.url }}:{{ .Values.manager.image.tag }}'
       - op: replace
         path: /spec/template/spec/containers/0/args/1
-        value: --enableBMHNameBasedPreallocation=false
+        value: --enableBMHNameBasedPreallocation=true
       - op: replace
         path: /spec/template/spec/containers/0/args/2
         value: --diagnostics-address=:8443


### PR DESCRIPTION
With this flag false (the default), IPClaim names include a randomly assigned index making them unpredictable and incompatible with IPPool preAllocations. Setting it true uses {bmhName}-{poolName} naming, enabling deterministic IP assignment in DHCP-less environments. Existing provisioned nodes are unaffected as the controller falls back to data-name lookup before creating new claims.