### PR TITLE
MGMT-24843: Parameterize CAPM3 BMH-based IPCLaim names

### DIFF
--- a/charts/cluster-api-provider-metal3-k8s/templates/apps_v1_deployment_mce-capm3-controller-manager.yaml
+++ b/charts/cluster-api-provider-metal3-k8s/templates/apps_v1_deployment_mce-capm3-controller-manager.yaml
@@ -27,7 +27,10 @@ spec:
       containers:
       - args:
         - --webhook-port=9443
-        - --enableBMHNameBasedPreallocation=true
+        - --enableBMHNameBasedPreallocation={{ if and .Values.global .Values.global.templateOverrides
+          (hasKey .Values.global.templateOverrides "enablebmhnamebasedpreallocation")
+          }}{{ .Values.global.templateOverrides.enablebmhnamebasedpreallocation }}{{
+          else }}false{{ end }}
         - --diagnostics-address=:8443
         - --insecure-diagnostics=false
         - --tls-min-version=VersionTLS13

--- a/charts/cluster-api-provider-metal3-k8s/values.yaml
+++ b/charts/cluster-api-provider-metal3-k8s/values.yaml
@@ -1,3 +1,5 @@
+global:
+  templateOverrides: {}
 manager:
   image:
     tag: v5.0

--- a/charts/cluster-api-provider-metal3/templates/apps_v1_deployment_mce-capm3-controller-manager.yaml
+++ b/charts/cluster-api-provider-metal3/templates/apps_v1_deployment_mce-capm3-controller-manager.yaml
@@ -27,7 +27,10 @@ spec:
       containers:
       - args:
         - --webhook-port=9443
-        - --enableBMHNameBasedPreallocation=true
+        - --enableBMHNameBasedPreallocation={{ if and .Values.global .Values.global.templateOverrides
+          (hasKey .Values.global.templateOverrides "enablebmhnamebasedpreallocation")
+          }}{{ .Values.global.templateOverrides.enablebmhnamebasedpreallocation }}{{
+          else }}false{{ end }}
         - --diagnostics-address=:8443
         - --insecure-diagnostics=false
         - --tls-min-version=VersionTLS13

--- a/charts/cluster-api-provider-metal3/values.yaml
+++ b/charts/cluster-api-provider-metal3/values.yaml
@@ -1,3 +1,5 @@
+global:
+  templateOverrides: {}
 manager:
   image:
     tag: v5.0

--- a/config-k8s/cluster-api-provider-metal3/kustomization.yaml
+++ b/config-k8s/cluster-api-provider-metal3/kustomization.yaml
@@ -131,7 +131,7 @@ patches:
         value: '{{ .Values.manager.image.url }}:{{ .Values.manager.image.tag }}'
       - op: replace
         path: /spec/template/spec/containers/0/args/1
-        value: --enableBMHNameBasedPreallocation=true
+        value: --enableBMHNameBasedPreallocation={{ if and .Values.global .Values.global.templateOverrides (hasKey .Values.global.templateOverrides "enablebmhnamebasedpreallocation") }}{{ .Values.global.templateOverrides.enablebmhnamebasedpreallocation }}{{ else }}false{{ end }}
       - op: replace
         path: /spec/template/spec/containers/0/args/2
         value: --diagnostics-address=:8443

--- a/config/cluster-api-provider-metal3/kustomization.yaml
+++ b/config/cluster-api-provider-metal3/kustomization.yaml
@@ -103,7 +103,7 @@ patches:
         value: '{{ .Values.manager.image.url }}:{{ .Values.manager.image.tag }}'
       - op: replace
         path: /spec/template/spec/containers/0/args/1
-        value: --enableBMHNameBasedPreallocation=true
+        value: --enableBMHNameBasedPreallocation={{ if and .Values.global .Values.global.templateOverrides (hasKey .Values.global.templateOverrides "enablebmhnamebasedpreallocation") }}{{ .Values.global.templateOverrides.enablebmhnamebasedpreallocation }}{{ else }}false{{ end }}
       - op: replace
         path: /spec/template/spec/containers/0/args/2
         value: --diagnostics-address=:8443


### PR DESCRIPTION
Parameterizes the value set to true in https://github.com/stolostron/cluster-api-installer/pull/745 to allow opting in via template overrides instead of making the change universal