### PR TITLE
fix: set AZURE_USER_AGENT_SUFFIX to actual CAPZ image tag (ARO-24154)

### DIFF
--- a/charts/cluster-api-provider-azure-k8s/templates/v1_secret_aso-controller-settings.yaml
+++ b/charts/cluster-api-provider-azure-k8s/templates/v1_secret_aso-controller-settings.yaml
@@ -12,6 +12,6 @@ stringData:
   AZURE_SUBSCRIPTION_ID: ""
   AZURE_SYNC_PERIOD: ""
   AZURE_TENANT_ID: ""
-  AZURE_USER_AGENT_SUFFIX: cluster-api-provider-azure/main
+  AZURE_USER_AGENT_SUFFIX: cluster-api-provider-azure/{{.Values.manager.image.tag}}
   USE_WORKLOAD_IDENTITY_AUTH: ""
 type: Opaque

--- a/charts/cluster-api-provider-azure-kind/templates/v1_secret_aso-controller-settings.yaml
+++ b/charts/cluster-api-provider-azure-kind/templates/v1_secret_aso-controller-settings.yaml
@@ -11,5 +11,5 @@ stringData:
   AZURE_SUBSCRIPTION_ID: ""
   AZURE_SYNC_PERIOD: ""
   AZURE_TENANT_ID: ""
-  AZURE_USER_AGENT_SUFFIX: cluster-api-provider-azure/main
+  AZURE_USER_AGENT_SUFFIX: cluster-api-provider-azure/{{.Values.manager.image.tag}}
 type: Opaque

--- a/charts/cluster-api-provider-azure/templates/v1_secret_aso-controller-settings.yaml
+++ b/charts/cluster-api-provider-azure/templates/v1_secret_aso-controller-settings.yaml
@@ -12,6 +12,6 @@ stringData:
   AZURE_SUBSCRIPTION_ID: ""
   AZURE_SYNC_PERIOD: ""
   AZURE_TENANT_ID: ""
-  AZURE_USER_AGENT_SUFFIX: cluster-api-provider-azure/main
+  AZURE_USER_AGENT_SUFFIX: cluster-api-provider-azure/{{.Values.manager.image.tag}}
   USE_WORKLOAD_IDENTITY_AUTH: ""
 type: Opaque

--- a/config-k8s/cluster-api-provider-azure/kustomization.yaml
+++ b/config-k8s/cluster-api-provider-azure/kustomization.yaml
@@ -106,6 +106,9 @@ patches:
       - op: add
         path: /stringData/USE_WORKLOAD_IDENTITY_AUTH
         value: ""
+      - op: replace
+        path: /stringData/AZURE_USER_AGENT_SUFFIX
+        value: 'cluster-api-provider-azure/{{.Values.manager.image.tag}}'
   # Replace Deployment with default values & helm chart value
   - target:
       version: v1

--- a/config-kind/cluster-api-provider-azure/kustomization.yaml
+++ b/config-kind/cluster-api-provider-azure/kustomization.yaml
@@ -41,6 +41,14 @@ patches:
         path: /spec/template/spec/containers/0/args/-
         value: --crd-management=none
   - target:
+      version: v1
+      kind: Secret
+      name: aso-controller-settings
+    patch: |-
+      - op: replace
+        path: /stringData/AZURE_USER_AGENT_SUFFIX
+        value: 'cluster-api-provider-azure/{{.Values.manager.image.tag}}'
+  - target:
       kind: ServiceAccount
       name: capz-manager
     patch: |-

--- a/config/cluster-api-provider-azure/kustomization.yaml
+++ b/config/cluster-api-provider-azure/kustomization.yaml
@@ -80,6 +80,9 @@ patches:
       - op: add
         path: /stringData/USE_WORKLOAD_IDENTITY_AUTH
         value: ""
+      - op: replace
+        path: /stringData/AZURE_USER_AGENT_SUFFIX
+        value: 'cluster-api-provider-azure/{{.Values.manager.image.tag}}'
   # Replace Deployment with default values & helm chart value
   - target:
       version: v1


### PR DESCRIPTION
## Summary
- Replace hardcoded `AZURE_USER_AGENT_SUFFIX: cluster-api-provider-azure/main` with `cluster-api-provider-azure/{{.Values.manager.image.tag}}` in the `aso-controller-settings` secret
- Applied to all three kustomize overlays (`config/`, `config-k8s/`, `config-kind/`) and regenerated Helm charts
- ARM requests from ASO now carry the actual deployed CAPZ version (e.g., `cluster-api-provider-azure/v5.0.0-59235ca`), allowing SREs to identify which version is making ARM calls during incidents

## Context
During [AROSLSRE-720](https://redhat.atlassian.net/browse/AROSLSRE-720), ASO hot-looped VNet deletion and the User-Agent was empty/unhelpful. This fix is part of a three-repo change:
1. **CAPZ** [stolostron/cluster-api-provider-azure#399](https://github.com/stolostron/cluster-api-provider-azure/pull/399) — set `gitVersion` via ldflags in Dockerfile
2. **ASO** [stolostron/azure-service-operator#451](https://github.com/stolostron/azure-service-operator/pull/451) — set `BuildVersion` via ldflags in Dockerfile
3. **cluster-api-installer** (this PR) — template `AZURE_USER_AGENT_SUFFIX` with actual image tag

## Test plan
- [x] Deployed with `test0.sh aro` using PR images (`CAPZ_PR_NO=399`, `ASO_PR_NO=451`)
- [x] Verified User-Agent in mockup-proxy logs: `aso-controller/v5.0.0-3f9546b cluster-api-provider-azure/5.0.0-pr-399`

Fixes: [ARO-24154](https://redhat.atlassian.net/browse/ARO-24154)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AROSLSRE-720]: https://redhat.atlassian.net/browse/AROSLSRE-720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARO-24154]: https://redhat.atlassian.net/browse/ARO-24154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ