### PR TITLE
ACM-31156: Add NetworkPolicies for CAPOA components

### DIFF
--- a/config/cluster-api-provider-openshift-assisted/bootstrap/base/capoa-bootstrap-networkpolicy.yaml
+++ b/config/cluster-api-provider-openshift-assisted/bootstrap/base/capoa-bootstrap-networkpolicy.yaml
@@ -1,0 +1,60 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: capoa-bootstrap-controller-manager
+  labels:
+    control-plane: capoa-bootstrap-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: capoa-bootstrap-controller-manager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    - ports:
+        - protocol: TCP
+          port: 9443
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              component: apiserver
+      ports:
+        - protocol: TCP
+          port: 6443
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 8090
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/config/cluster-api-provider-openshift-assisted/bootstrap/base/kustomization.yaml
+++ b/config/cluster-api-provider-openshift-assisted/bootstrap/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - capoa-bootstrap-networkpolicy.yaml

--- a/config/cluster-api-provider-openshift-assisted/bootstrap/kustomization.yaml
+++ b/config/cluster-api-provider-openshift-assisted/bootstrap/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: 'multicluster-engine'
 
 resources:
 - default/
+- base/
 
 patches:
 - target:

--- a/config/cluster-api-provider-openshift-assisted/controlplane/base/capoa-controlplane-networkpolicy.yaml
+++ b/config/cluster-api-provider-openshift-assisted/controlplane/base/capoa-controlplane-networkpolicy.yaml
@@ -1,0 +1,52 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: capoa-controlplane-controller-manager
+  labels:
+    control-plane: capoa-controlplane-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: capoa-controlplane-controller-manager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    - ports:
+        - protocol: TCP
+          port: 9443
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 6443
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/config/cluster-api-provider-openshift-assisted/controlplane/base/kustomization.yaml
+++ b/config/cluster-api-provider-openshift-assisted/controlplane/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - capoa-controlplane-networkpolicy.yaml

--- a/config/cluster-api-provider-openshift-assisted/controlplane/kustomization.yaml
+++ b/config/cluster-api-provider-openshift-assisted/controlplane/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: 'multicluster-engine'
 
 resources:
 - default/
+- base/
 
 patches:
 - target:


### PR DESCRIPTION
## Summary

Adds per-component NetworkPolicies for both CAPOA providers via kustomize overlays in `config/` (OCP only, not `config-k8s/`).

**Bootstrap provider:**
- Ingress: same-namespace traffic, monitoring (8080), webhook (9443)
- Egress: DNS (5353), K8s API (6443), assisted-service (8090), HTTPS (443)

**Controlplane provider:**
- Ingress: same-namespace traffic, monitoring (8080), webhook (9443)
- Egress: DNS (5353), spoke cluster APIs (6443), container registries (443)

NetworkPolicy files are placed in `bootstrap/base/` and `controlplane/base/` and referenced as resources in the parent kustomization. The namespace is rewritten to `multicluster-engine` automatically by the kustomize overlay.

## Related

- Jira: [ACM-31156](https://redhat.atlassian.net/browse/ACM-31156)
- Epic: [ACM-31152](https://redhat.atlassian.net/browse/ACM-31152) (network policies for all ACM components)

[ACM-31156]: https://redhat.atlassian.net/browse/ACM-31156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-31152]: https://redhat.atlassian.net/browse/ACM-31152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ