### PR TITLE
ACM-41090: capoa-bootstrap-controller-manager NetworkPolicy blocks API server egress due to incorrect pod selector

### DIFF
--- a/charts/cluster-api-provider-openshift-assisted/templates/networking.k8s.io_v1_networkpolicy_capoa-bootstrap-controller-manager.yaml
+++ b/charts/cluster-api-provider-openshift-assisted/templates/networking.k8s.io_v1_networkpolicy_capoa-bootstrap-controller-manager.yaml
@@ -20,10 +20,10 @@ spec:
     - port: 6443
       protocol: TCP
     to:
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: apiserver
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    - ipBlock:
+        cidr: ::/0
   - ports:
     - port: 8090
       protocol: TCP

--- a/config/cluster-api-provider-openshift-assisted/bootstrap/base/capoa-bootstrap-networkpolicy.yaml
+++ b/config/cluster-api-provider-openshift-assisted/bootstrap/base/capoa-bootstrap-networkpolicy.yaml
@@ -35,10 +35,10 @@ spec:
         - protocol: TCP
           port: 5353
     - to:
-        - namespaceSelector: {}
-          podSelector:
-            matchLabels:
-              component: apiserver
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
       ports:
         - protocol: TCP
           port: 6443


### PR DESCRIPTION
Fix capoa-bootstrap-controller-manager CrashLoopBackOff on OCP 5.0 caused by NetworkPolicy egress rule using `component: apiserver` podSelector that doesn't match OCP 5.0 kube-apiserver pods.

Replace the podSelector rule with `ipBlock: 0.0.0.0/0` on port 6443, matching the pattern already used by the controlplane provider NetworkPolicy.
